### PR TITLE
Refactored IeeeAddress

### DIFF
--- a/src/ZigBeeNet/IeeeAddress.cs
+++ b/src/ZigBeeNet/IeeeAddress.cs
@@ -47,11 +47,11 @@ namespace ZigBeeNet
         {
             try
             {
-                _address = BitConverter.GetBytes(Convert.ToUInt64(address));
+                _address = BitConverter.GetBytes(Convert.ToUInt64(address, 16));
             }
             catch (FormatException)
             {
-                throw new ArgumentException("IeeeAddress string must contain valid UInt64 value");
+                throw new ArgumentException("IeeeAddress string must contain valid hexadecimal value");
             }
         }
 
@@ -108,7 +108,7 @@ namespace ZigBeeNet
 
         public override string ToString()
         {
-            return Value.ToString();
+            return Value.ToString("X");
         }
 
         public int CompareTo(IeeeAddress other)

--- a/src/ZigBeeNet/IeeeAddress.cs
+++ b/src/ZigBeeNet/IeeeAddress.cs
@@ -18,38 +18,38 @@ namespace ZigBeeNet
             }
             set
             {
-                SetAddress(value);
+                _address = BitConverter.GetBytes(value);
             }
         }
 
         /// <summary>
-         /// Default constructor. Creates an address 0
-         /// </summary>
+        /// Default constructor. Creates an address 0
+        /// </summary>
         public IeeeAddress()
         {
             this._address = new byte[] { 0, 0, 0, 0, 0, 0, 0, 0 };
         }
 
         /// <summary>
-         /// Create an <see cref="IeeeAddress"> from a <see cref="BigInteger">
-         ///
-         /// <param name="address">the address as a <see cref="BigInteger"></param>
-         /// </summary>
+        /// Create an <see cref="IeeeAddress"> from a <see cref="BigInteger">
+        ///
+        /// <param name="address">the address as a <see cref="BigInteger"></param>
+        /// </summary>
         public IeeeAddress(BigInteger address) : this()
         {
-            SetAddress((ulong)address);
+            _address = BitConverter.GetBytes((ulong)address);
         }
 
         /// <summary>
-         /// Create an <see cref="IeeeAddress"> from a <see cref="String">
-         ///
-         /// <param name="address">the address as a <see cref="String"></param>
-         /// </summary>
+        /// Create an <see cref="IeeeAddress"> from a <see cref="String">
+        ///
+        /// <param name="address">the address as a <see cref="String"></param>
+        /// </summary>
         public IeeeAddress(string address) : this()
         {
             try
             {
-                SetAddress(Convert.ToUInt64(address, 16));
+              _address = BitConverter.GetBytes(Convert.ToUInt64(address, 16));
             }
             catch (FormatException e)
             {
@@ -58,11 +58,11 @@ namespace ZigBeeNet
         }
 
         /// <summary>
-         /// Create an <see cref="IeeeAddress"> from an int array
-         ///
-         /// <param name="address">the address as an int array. Array length must be 8.</param>
-         /// @throws IllegalArgumentException
-         /// </summary>
+        /// Create an <see cref="IeeeAddress"> from an int array
+        ///
+        /// <param name="address">the address as an int array. Array length must be 8.</param>
+        /// @throws IllegalArgumentException
+        /// </summary>
         public IeeeAddress(byte[] address)
         {
             if (address.Length != 8)
@@ -110,7 +110,7 @@ namespace ZigBeeNet
         }
 
         public override string ToString()
-        {             
+        {
             return Value.ToString();
         }
 
@@ -137,19 +137,5 @@ namespace ZigBeeNet
             }
             return 0;
         }
-
-        private void SetAddress(ulong longVal)
-        {
-            this._address[0] = (byte)(longVal & 0xff);
-            this._address[1] = (byte)((longVal >> 8) & 0xff);
-            this._address[2] = (byte)((longVal >> 16) & 0xff);
-            this._address[3] = (byte)((longVal >> 24) & 0xff);
-            this._address[4] = (byte)((longVal >> 32) & 0xff);
-            this._address[5] = (byte)((longVal >> 40) & 0xff);
-            this._address[6] = (byte)((longVal >> 48) & 0xff);
-            this._address[7] = (byte)((longVal >> 56) & 0xff);
-
-        }
-
     }
 }

--- a/src/ZigBeeNet/IeeeAddress.cs
+++ b/src/ZigBeeNet/IeeeAddress.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Numerics;
-using System.Text;
 using ZigBeeNet.Util;
 
 namespace ZigBeeNet
@@ -27,7 +25,7 @@ namespace ZigBeeNet
         /// </summary>
         public IeeeAddress()
         {
-            this._address = new byte[] { 0, 0, 0, 0, 0, 0, 0, 0 };
+            this._address = new byte[8];
         }
 
         /// <summary>
@@ -49,9 +47,9 @@ namespace ZigBeeNet
         {
             try
             {
-              _address = BitConverter.GetBytes(Convert.ToUInt64(address, 16));
+                _address = BitConverter.GetBytes(Convert.ToUInt64(address, 16));
             }
-            catch (FormatException e)
+            catch (FormatException)
             {
                 throw new ArgumentException("IeeeAddress string must contain valid hexadecimal value");
             }
@@ -61,15 +59,14 @@ namespace ZigBeeNet
         /// Create an <see cref="IeeeAddress"> from an int array
         ///
         /// <param name="address">the address as an int array. Array length must be 8.</param>
-        /// @throws IllegalArgumentException
+        /// @throws ArgumentOutOfRangeException
         /// </summary>
         public IeeeAddress(byte[] address)
         {
             if (address.Length != 8)
-            {
-                throw new ArgumentNullException("IeeeAddress array length must be 8");
-            }
-            _address = address;//Arrays.copyOf(address, 8);
+                throw new ArgumentOutOfRangeException("IeeeAddress array length must be 8");
+
+            _address = address;
         }
 
         /// <summary>
@@ -89,23 +86,23 @@ namespace ZigBeeNet
         public override bool Equals(object obj)
         {
             if (obj == null)
-            {
                 return false;
-            }
-
-            if (!typeof(IeeeAddress).IsAssignableFrom(obj.GetType()))
+            
+            if (obj is IeeeAddress other)
             {
-                return false;
-            }
-
-            IeeeAddress other = (IeeeAddress)obj;
-            for (int cnt = 0; cnt < 8; cnt++)
-            {
-                if (other._address[cnt] != _address[cnt])
+                for (int cnt = 0; cnt < 8; cnt++)
                 {
-                    return false;
+                    if (other._address[cnt] != _address[cnt])
+                    {
+                        return false;
+                    }
                 }
             }
+            else
+            {
+                return false;
+            }
+
             return true;
         }
 
@@ -117,14 +114,7 @@ namespace ZigBeeNet
         public int CompareTo(IeeeAddress other)
         {
             if (other == null)
-            {
                 return -1;
-            }
-
-            if (!typeof(IeeeAddress).IsAssignableFrom(other.GetType()))
-            {
-                return -1;
-            }
 
             for (int cnt = 0; cnt < 8; cnt++)
             {
@@ -135,6 +125,7 @@ namespace ZigBeeNet
 
                 return other._address[cnt] < _address[cnt] ? 1 : -1;
             }
+
             return 0;
         }
     }

--- a/src/ZigBeeNet/IeeeAddress.cs
+++ b/src/ZigBeeNet/IeeeAddress.cs
@@ -47,11 +47,11 @@ namespace ZigBeeNet
         {
             try
             {
-                _address = BitConverter.GetBytes(Convert.ToUInt64(address, 16));
+                _address = BitConverter.GetBytes(Convert.ToUInt64(address));
             }
             catch (FormatException)
             {
-                throw new ArgumentException("IeeeAddress string must contain valid hexadecimal value");
+                throw new ArgumentException("IeeeAddress string must contain valid UInt64 value");
             }
         }
 


### PR DESCRIPTION
Hello first of all many thanks for this great library.
I refactored the IeeAddress because my Ikea Tradfri lamp together with my CC2531 and enabled NetworkSerializer threw an exception.

Instead of the bit shifting in the `SetAddress` the method `BitConverter.GetBytes` contained in the .Net framework is used now. Which should make the code easier to read.

I also fixed an OverflowException when converting the string in the constructor to the byte[]. The problem occurred when I serialized my Tradfri lamp using the `JsonNetworkSerializer` and rebooted the network.