### PR TITLE
Makes the properties of ZigBeeCommand and ZclCommand internal

### DIFF
--- a/samples/ZigBeeNet.PlayGround/Program.cs
+++ b/samples/ZigBeeNet.PlayGround/Program.cs
@@ -252,7 +252,7 @@ namespace ZigBeeNet.PlayGround
                                     {
                                         NodeDescriptorRequest nodeDescriptorRequest = new NodeDescriptorRequest()
                                         {
-                                            DestinationAddress = endpointAddress,
+                                            Destination = endpointAddress,
                                             NwkAddrOfInterest = addr
                                         };
 
@@ -316,7 +316,7 @@ namespace ZigBeeNet.PlayGround
                                             ZclStatus statusCode = response.Records[0].Status;
                                             if (statusCode == ZclStatus.SUCCESS)
                                             {
-                                                Console.WriteLine("Cluster " + response.ClusterId.ToString("X4") + ", Attribute "
+                                                Console.WriteLine("Cluster " + response + ", Attribute "
                                                         + response.Records[0].AttributeIdentifier + ", type "
                                                         + response.Records[0].AttributeDataType + ", value: "
                                                         + response.Records[0].AttributeValue);

--- a/src/ZigBeeNet.CodeGenerator/ZclProtocolCodeGenerator.cs
+++ b/src/ZigBeeNet.CodeGenerator/ZclProtocolCodeGenerator.cs
@@ -259,7 +259,7 @@ namespace ZigBeeNet.CodeGenerator
                         if (fields.Count > 0)
                         {
                             code.AppendLine();
-                            code.AppendLine("        public override void Serialize(ZclFieldSerializer serializer)");
+                            code.AppendLine("        internal override void Serialize(ZclFieldSerializer serializer)");
                             code.AppendLine("        {");
                             foreach (Field field in fields)
                             {
@@ -313,7 +313,7 @@ namespace ZigBeeNet.CodeGenerator
                             code.AppendLine("        }");
 
                             code.AppendLine();
-                            code.AppendLine("        public override void Deserialize(ZclFieldDeserializer deserializer)");
+                            code.AppendLine("        internal override void Deserialize(ZclFieldDeserializer deserializer)");
                             code.AppendLine("        {");
 
                             foreach (Field field in fields)

--- a/src/ZigBeeNet/ZCL/Clusters/Alarms/AlarmCommand.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/Alarms/AlarmCommand.cs
@@ -48,13 +48,13 @@ namespace ZigBeeNet.ZCL.Clusters.Alarms
             CommandDirection = ZclCommandDirection.SERVER_TO_CLIENT;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(AlarmCode, ZclDataType.Get(DataType.ENUMERATION_8_BIT));
             serializer.Serialize(ClusterIdentifier, ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             AlarmCode = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.ENUMERATION_8_BIT));
             ClusterIdentifier = deserializer.Deserialize<ushort>(ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));

--- a/src/ZigBeeNet/ZCL/Clusters/Alarms/GetAlarmResponse.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/Alarms/GetAlarmResponse.cs
@@ -58,7 +58,7 @@ namespace ZigBeeNet.ZCL.Clusters.Alarms
             CommandDirection = ZclCommandDirection.SERVER_TO_CLIENT;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(Status, ZclDataType.Get(DataType.ENUMERATION_8_BIT));
             serializer.Serialize(AlarmCode, ZclDataType.Get(DataType.ENUMERATION_8_BIT));
@@ -66,7 +66,7 @@ namespace ZigBeeNet.ZCL.Clusters.Alarms
             serializer.Serialize(Timestamp, ZclDataType.Get(DataType.UNSIGNED_32_BIT_INTEGER));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             Status = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.ENUMERATION_8_BIT));
             AlarmCode = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.ENUMERATION_8_BIT));

--- a/src/ZigBeeNet/ZCL/Clusters/Alarms/ResetAlarmCommand.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/Alarms/ResetAlarmCommand.cs
@@ -42,13 +42,13 @@ namespace ZigBeeNet.ZCL.Clusters.Alarms
             CommandDirection = ZclCommandDirection.CLIENT_TO_SERVER;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(AlarmCode, ZclDataType.Get(DataType.ENUMERATION_8_BIT));
             serializer.Serialize(ClusterIdentifier, ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             AlarmCode = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.ENUMERATION_8_BIT));
             ClusterIdentifier = deserializer.Deserialize<ushort>(ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));

--- a/src/ZigBeeNet/ZCL/Clusters/ColorControl/ColorLoopSetCommand.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/ColorControl/ColorLoopSetCommand.cs
@@ -57,7 +57,7 @@ namespace ZigBeeNet.ZCL.Clusters.ColorControl
             CommandDirection = ZclCommandDirection.CLIENT_TO_SERVER;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(UpdateFlags, ZclDataType.Get(DataType.BITMAP_8_BIT));
             serializer.Serialize(Action, ZclDataType.Get(DataType.ENUMERATION_8_BIT));
@@ -66,7 +66,7 @@ namespace ZigBeeNet.ZCL.Clusters.ColorControl
             serializer.Serialize(StartHue, ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             UpdateFlags = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.BITMAP_8_BIT));
             Action = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.ENUMERATION_8_BIT));

--- a/src/ZigBeeNet/ZCL/Clusters/ColorControl/EnhancedMoveToHueAndSaturationCommand.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/ColorControl/EnhancedMoveToHueAndSaturationCommand.cs
@@ -47,14 +47,14 @@ namespace ZigBeeNet.ZCL.Clusters.ColorControl
             CommandDirection = ZclCommandDirection.CLIENT_TO_SERVER;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(Hue, ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));
             serializer.Serialize(Saturation, ZclDataType.Get(DataType.ENUMERATION_8_BIT));
             serializer.Serialize(TransitionTime, ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             Hue = deserializer.Deserialize<ushort>(ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));
             Saturation = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.ENUMERATION_8_BIT));

--- a/src/ZigBeeNet/ZCL/Clusters/ColorControl/EnhancedMoveToHueCommand.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/ColorControl/EnhancedMoveToHueCommand.cs
@@ -47,14 +47,14 @@ namespace ZigBeeNet.ZCL.Clusters.ColorControl
             CommandDirection = ZclCommandDirection.CLIENT_TO_SERVER;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(Hue, ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));
             serializer.Serialize(Direction, ZclDataType.Get(DataType.ENUMERATION_8_BIT));
             serializer.Serialize(TransitionTime, ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             Hue = deserializer.Deserialize<ushort>(ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));
             Direction = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.ENUMERATION_8_BIT));

--- a/src/ZigBeeNet/ZCL/Clusters/ColorControl/EnhancedStepHueCommand.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/ColorControl/EnhancedStepHueCommand.cs
@@ -47,14 +47,14 @@ namespace ZigBeeNet.ZCL.Clusters.ColorControl
             CommandDirection = ZclCommandDirection.CLIENT_TO_SERVER;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(StepMode, ZclDataType.Get(DataType.ENUMERATION_8_BIT));
             serializer.Serialize(StepSize, ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));
             serializer.Serialize(TransitionTime, ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             StepMode = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.ENUMERATION_8_BIT));
             StepSize = deserializer.Deserialize<ushort>(ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));

--- a/src/ZigBeeNet/ZCL/Clusters/ColorControl/MoveColorCommand.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/ColorControl/MoveColorCommand.cs
@@ -42,13 +42,13 @@ namespace ZigBeeNet.ZCL.Clusters.ColorControl
             CommandDirection = ZclCommandDirection.CLIENT_TO_SERVER;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(RateX, ZclDataType.Get(DataType.SIGNED_16_BIT_INTEGER));
             serializer.Serialize(RateY, ZclDataType.Get(DataType.SIGNED_16_BIT_INTEGER));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             RateX = deserializer.Deserialize<short>(ZclDataType.Get(DataType.SIGNED_16_BIT_INTEGER));
             RateY = deserializer.Deserialize<short>(ZclDataType.Get(DataType.SIGNED_16_BIT_INTEGER));

--- a/src/ZigBeeNet/ZCL/Clusters/ColorControl/MoveHueCommand.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/ColorControl/MoveHueCommand.cs
@@ -42,13 +42,13 @@ namespace ZigBeeNet.ZCL.Clusters.ColorControl
             CommandDirection = ZclCommandDirection.CLIENT_TO_SERVER;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(MoveMode, ZclDataType.Get(DataType.ENUMERATION_8_BIT));
             serializer.Serialize(Rate, ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             MoveMode = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.ENUMERATION_8_BIT));
             Rate = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));

--- a/src/ZigBeeNet/ZCL/Clusters/ColorControl/MoveSaturationCommand.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/ColorControl/MoveSaturationCommand.cs
@@ -42,13 +42,13 @@ namespace ZigBeeNet.ZCL.Clusters.ColorControl
             CommandDirection = ZclCommandDirection.CLIENT_TO_SERVER;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(MoveMode, ZclDataType.Get(DataType.ENUMERATION_8_BIT));
             serializer.Serialize(Rate, ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             MoveMode = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.ENUMERATION_8_BIT));
             Rate = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));

--- a/src/ZigBeeNet/ZCL/Clusters/ColorControl/MoveToColorCommand.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/ColorControl/MoveToColorCommand.cs
@@ -47,14 +47,14 @@ namespace ZigBeeNet.ZCL.Clusters.ColorControl
             CommandDirection = ZclCommandDirection.CLIENT_TO_SERVER;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(ColorX, ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));
             serializer.Serialize(ColorY, ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));
             serializer.Serialize(TransitionTime, ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             ColorX = deserializer.Deserialize<ushort>(ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));
             ColorY = deserializer.Deserialize<ushort>(ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));

--- a/src/ZigBeeNet/ZCL/Clusters/ColorControl/MoveToColorTemperatureCommand.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/ColorControl/MoveToColorTemperatureCommand.cs
@@ -42,13 +42,13 @@ namespace ZigBeeNet.ZCL.Clusters.ColorControl
             CommandDirection = ZclCommandDirection.CLIENT_TO_SERVER;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(ColorTemperature, ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));
             serializer.Serialize(TransitionTime, ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             ColorTemperature = deserializer.Deserialize<ushort>(ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));
             TransitionTime = deserializer.Deserialize<ushort>(ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));

--- a/src/ZigBeeNet/ZCL/Clusters/ColorControl/MoveToHueAndSaturationCommand.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/ColorControl/MoveToHueAndSaturationCommand.cs
@@ -47,14 +47,14 @@ namespace ZigBeeNet.ZCL.Clusters.ColorControl
             CommandDirection = ZclCommandDirection.CLIENT_TO_SERVER;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(Hue, ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));
             serializer.Serialize(Saturation, ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));
             serializer.Serialize(TransitionTime, ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             Hue = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));
             Saturation = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));

--- a/src/ZigBeeNet/ZCL/Clusters/ColorControl/MoveToHueCommand.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/ColorControl/MoveToHueCommand.cs
@@ -47,14 +47,14 @@ namespace ZigBeeNet.ZCL.Clusters.ColorControl
             CommandDirection = ZclCommandDirection.CLIENT_TO_SERVER;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(Hue, ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));
             serializer.Serialize(Direction, ZclDataType.Get(DataType.ENUMERATION_8_BIT));
             serializer.Serialize(TransitionTime, ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             Hue = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));
             Direction = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.ENUMERATION_8_BIT));

--- a/src/ZigBeeNet/ZCL/Clusters/ColorControl/MoveToSaturationCommand.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/ColorControl/MoveToSaturationCommand.cs
@@ -42,13 +42,13 @@ namespace ZigBeeNet.ZCL.Clusters.ColorControl
             CommandDirection = ZclCommandDirection.CLIENT_TO_SERVER;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(Saturation, ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));
             serializer.Serialize(TransitionTime, ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             Saturation = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));
             TransitionTime = deserializer.Deserialize<ushort>(ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));

--- a/src/ZigBeeNet/ZCL/Clusters/ColorControl/StepColorCommand.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/ColorControl/StepColorCommand.cs
@@ -47,14 +47,14 @@ namespace ZigBeeNet.ZCL.Clusters.ColorControl
             CommandDirection = ZclCommandDirection.CLIENT_TO_SERVER;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(StepX, ZclDataType.Get(DataType.SIGNED_16_BIT_INTEGER));
             serializer.Serialize(StepY, ZclDataType.Get(DataType.SIGNED_16_BIT_INTEGER));
             serializer.Serialize(TransitionTime, ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             StepX = deserializer.Deserialize<short>(ZclDataType.Get(DataType.SIGNED_16_BIT_INTEGER));
             StepY = deserializer.Deserialize<short>(ZclDataType.Get(DataType.SIGNED_16_BIT_INTEGER));

--- a/src/ZigBeeNet/ZCL/Clusters/ColorControl/StepHueCommand.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/ColorControl/StepHueCommand.cs
@@ -47,14 +47,14 @@ namespace ZigBeeNet.ZCL.Clusters.ColorControl
             CommandDirection = ZclCommandDirection.CLIENT_TO_SERVER;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(StepMode, ZclDataType.Get(DataType.ENUMERATION_8_BIT));
             serializer.Serialize(StepSize, ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));
             serializer.Serialize(TransitionTime, ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             StepMode = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.ENUMERATION_8_BIT));
             StepSize = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));

--- a/src/ZigBeeNet/ZCL/Clusters/ColorControl/StepSaturationCommand.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/ColorControl/StepSaturationCommand.cs
@@ -47,14 +47,14 @@ namespace ZigBeeNet.ZCL.Clusters.ColorControl
             CommandDirection = ZclCommandDirection.CLIENT_TO_SERVER;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(StepMode, ZclDataType.Get(DataType.ENUMERATION_8_BIT));
             serializer.Serialize(StepSize, ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));
             serializer.Serialize(TransitionTime, ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             StepMode = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.ENUMERATION_8_BIT));
             StepSize = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));

--- a/src/ZigBeeNet/ZCL/Clusters/Commissioning/ResetStartupParametersCommand.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/Commissioning/ResetStartupParametersCommand.cs
@@ -42,13 +42,13 @@ namespace ZigBeeNet.ZCL.Clusters.Commissioning
             CommandDirection = ZclCommandDirection.CLIENT_TO_SERVER;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(Option, ZclDataType.Get(DataType.BITMAP_8_BIT));
             serializer.Serialize(Index, ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             Option = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.BITMAP_8_BIT));
             Index = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));

--- a/src/ZigBeeNet/ZCL/Clusters/Commissioning/ResetStartupParametersResponse.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/Commissioning/ResetStartupParametersResponse.cs
@@ -37,12 +37,12 @@ namespace ZigBeeNet.ZCL.Clusters.Commissioning
             CommandDirection = ZclCommandDirection.SERVER_TO_CLIENT;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(Status, ZclDataType.Get(DataType.ENUMERATION_8_BIT));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             Status = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.ENUMERATION_8_BIT));
         }

--- a/src/ZigBeeNet/ZCL/Clusters/Commissioning/RestartDeviceCommand.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/Commissioning/RestartDeviceCommand.cs
@@ -47,14 +47,14 @@ namespace ZigBeeNet.ZCL.Clusters.Commissioning
             CommandDirection = ZclCommandDirection.CLIENT_TO_SERVER;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(Option, ZclDataType.Get(DataType.BITMAP_8_BIT));
             serializer.Serialize(Delay, ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));
             serializer.Serialize(Jitter, ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             Option = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.BITMAP_8_BIT));
             Delay = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));

--- a/src/ZigBeeNet/ZCL/Clusters/Commissioning/RestartDeviceResponseResponse.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/Commissioning/RestartDeviceResponseResponse.cs
@@ -37,12 +37,12 @@ namespace ZigBeeNet.ZCL.Clusters.Commissioning
             CommandDirection = ZclCommandDirection.SERVER_TO_CLIENT;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(Status, ZclDataType.Get(DataType.ENUMERATION_8_BIT));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             Status = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.ENUMERATION_8_BIT));
         }

--- a/src/ZigBeeNet/ZCL/Clusters/Commissioning/RestoreStartupParametersCommand.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/Commissioning/RestoreStartupParametersCommand.cs
@@ -42,13 +42,13 @@ namespace ZigBeeNet.ZCL.Clusters.Commissioning
             CommandDirection = ZclCommandDirection.CLIENT_TO_SERVER;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(Option, ZclDataType.Get(DataType.BITMAP_8_BIT));
             serializer.Serialize(Index, ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             Option = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.BITMAP_8_BIT));
             Index = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));

--- a/src/ZigBeeNet/ZCL/Clusters/Commissioning/RestoreStartupParametersResponse.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/Commissioning/RestoreStartupParametersResponse.cs
@@ -37,12 +37,12 @@ namespace ZigBeeNet.ZCL.Clusters.Commissioning
             CommandDirection = ZclCommandDirection.SERVER_TO_CLIENT;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(Status, ZclDataType.Get(DataType.ENUMERATION_8_BIT));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             Status = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.ENUMERATION_8_BIT));
         }

--- a/src/ZigBeeNet/ZCL/Clusters/Commissioning/SaveStartupParametersCommand.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/Commissioning/SaveStartupParametersCommand.cs
@@ -42,13 +42,13 @@ namespace ZigBeeNet.ZCL.Clusters.Commissioning
             CommandDirection = ZclCommandDirection.CLIENT_TO_SERVER;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(Option, ZclDataType.Get(DataType.BITMAP_8_BIT));
             serializer.Serialize(Index, ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             Option = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.BITMAP_8_BIT));
             Index = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));

--- a/src/ZigBeeNet/ZCL/Clusters/Commissioning/SaveStartupParametersResponse.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/Commissioning/SaveStartupParametersResponse.cs
@@ -37,12 +37,12 @@ namespace ZigBeeNet.ZCL.Clusters.Commissioning
             CommandDirection = ZclCommandDirection.SERVER_TO_CLIENT;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(Status, ZclDataType.Get(DataType.ENUMERATION_8_BIT));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             Status = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.ENUMERATION_8_BIT));
         }

--- a/src/ZigBeeNet/ZCL/Clusters/DoorLock/LockDoorCommand.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/DoorLock/LockDoorCommand.cs
@@ -37,12 +37,12 @@ namespace ZigBeeNet.ZCL.Clusters.DoorLock
             CommandDirection = ZclCommandDirection.CLIENT_TO_SERVER;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(PinCode, ZclDataType.Get(DataType.OCTET_STRING));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             PinCode = deserializer.Deserialize<ByteArray>(ZclDataType.Get(DataType.OCTET_STRING));
         }

--- a/src/ZigBeeNet/ZCL/Clusters/DoorLock/LockDoorResponse.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/DoorLock/LockDoorResponse.cs
@@ -37,12 +37,12 @@ namespace ZigBeeNet.ZCL.Clusters.DoorLock
             CommandDirection = ZclCommandDirection.SERVER_TO_CLIENT;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(Status, ZclDataType.Get(DataType.ENUMERATION_8_BIT));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             Status = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.ENUMERATION_8_BIT));
         }

--- a/src/ZigBeeNet/ZCL/Clusters/DoorLock/UnlockDoorCommand.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/DoorLock/UnlockDoorCommand.cs
@@ -37,12 +37,12 @@ namespace ZigBeeNet.ZCL.Clusters.DoorLock
             CommandDirection = ZclCommandDirection.CLIENT_TO_SERVER;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(PinCode, ZclDataType.Get(DataType.OCTET_STRING));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             PinCode = deserializer.Deserialize<ByteArray>(ZclDataType.Get(DataType.OCTET_STRING));
         }

--- a/src/ZigBeeNet/ZCL/Clusters/DoorLock/UnlockDoorResponse.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/DoorLock/UnlockDoorResponse.cs
@@ -37,12 +37,12 @@ namespace ZigBeeNet.ZCL.Clusters.DoorLock
             CommandDirection = ZclCommandDirection.SERVER_TO_CLIENT;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(Status, ZclDataType.Get(DataType.ENUMERATION_8_BIT));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             Status = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.ENUMERATION_8_BIT));
         }

--- a/src/ZigBeeNet/ZCL/Clusters/General/ConfigureReportingCommand.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/General/ConfigureReportingCommand.cs
@@ -43,12 +43,12 @@ namespace ZigBeeNet.ZCL.Clusters.General
             CommandDirection = ZclCommandDirection.CLIENT_TO_SERVER;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(Records, ZclDataType.Get(DataType.N_X_ATTRIBUTE_REPORTING_CONFIGURATION_RECORD));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             Records = deserializer.Deserialize<List<AttributeReportingConfigurationRecord>>(ZclDataType.Get(DataType.N_X_ATTRIBUTE_REPORTING_CONFIGURATION_RECORD));
         }

--- a/src/ZigBeeNet/ZCL/Clusters/General/ConfigureReportingResponse.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/General/ConfigureReportingResponse.cs
@@ -54,7 +54,7 @@ namespace ZigBeeNet.ZCL.Clusters.General
             CommandDirection = ZclCommandDirection.CLIENT_TO_SERVER;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             if (Status == ZclStatus.SUCCESS)
             {
@@ -64,7 +64,7 @@ namespace ZigBeeNet.ZCL.Clusters.General
             serializer.Serialize(Records, ZclDataType.Get(DataType.N_X_ATTRIBUTE_STATUS_RECORD));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             if (deserializer.RemainingLength == 1)
             {

--- a/src/ZigBeeNet/ZCL/Clusters/General/DefaultResponse.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/General/DefaultResponse.cs
@@ -46,13 +46,13 @@ namespace ZigBeeNet.ZCL.Clusters.General
             CommandDirection = ZclCommandDirection.CLIENT_TO_SERVER;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(CommandIdentifier, ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));
             serializer.Serialize(StatusCode, ZclDataType.Get(DataType.ZCL_STATUS));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             CommandIdentifier = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));
             StatusCode = deserializer.Deserialize<ZclStatus>(ZclDataType.Get(DataType.ZCL_STATUS));

--- a/src/ZigBeeNet/ZCL/Clusters/General/DiscoverAttributesCommand.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/General/DiscoverAttributesCommand.cs
@@ -52,13 +52,13 @@ namespace ZigBeeNet.ZCL.Clusters.General
             CommandDirection = ZclCommandDirection.CLIENT_TO_SERVER;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(StartAttributeIdentifier, ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));
             serializer.Serialize(MaximumAttributeIdentifiers, ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             StartAttributeIdentifier = deserializer.Deserialize<ushort>(ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));
             MaximumAttributeIdentifiers = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));

--- a/src/ZigBeeNet/ZCL/Clusters/General/DiscoverAttributesExtended.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/General/DiscoverAttributesExtended.cs
@@ -45,13 +45,13 @@ namespace ZigBeeNet.ZCL.Clusters.General
             CommandDirection = ZclCommandDirection.CLIENT_TO_SERVER;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(StartAttributeIdentifier, ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));
             serializer.Serialize(MaximumAttributeIdentifiers, ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             StartAttributeIdentifier = deserializer.Deserialize<ushort>(ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));
             MaximumAttributeIdentifiers = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));

--- a/src/ZigBeeNet/ZCL/Clusters/General/DiscoverAttributesExtendedResponse.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/General/DiscoverAttributesExtendedResponse.cs
@@ -44,13 +44,13 @@ namespace ZigBeeNet.ZCL.Clusters.General
             CommandDirection = ZclCommandDirection.CLIENT_TO_SERVER;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(DiscoveryComplete, ZclDataType.Get(DataType.BOOLEAN));
             serializer.Serialize(AttributeInformation, ZclDataType.Get(DataType.N_X_EXTENDED_ATTRIBUTE_INFORMATION));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             DiscoveryComplete = deserializer.Deserialize<bool>(ZclDataType.Get(DataType.BOOLEAN));
             AttributeInformation = deserializer.Deserialize<List<ExtendedAttributeInformation>>(ZclDataType.Get(DataType.N_X_EXTENDED_ATTRIBUTE_INFORMATION));

--- a/src/ZigBeeNet/ZCL/Clusters/General/DiscoverAttributesResponse.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/General/DiscoverAttributesResponse.cs
@@ -53,13 +53,13 @@ namespace ZigBeeNet.ZCL.Clusters.General
             CommandDirection = ZclCommandDirection.CLIENT_TO_SERVER;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(DiscoveryComplete, ZclDataType.Get(DataType.BOOLEAN));
             serializer.Serialize(AttributeInformation, ZclDataType.Get(DataType.N_X_ATTRIBUTE_INFORMATION));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             DiscoveryComplete = deserializer.Deserialize<bool>(ZclDataType.Get(DataType.BOOLEAN));
             AttributeInformation = deserializer.Deserialize<List<AttributeInformation>>(ZclDataType.Get(DataType.N_X_ATTRIBUTE_INFORMATION));

--- a/src/ZigBeeNet/ZCL/Clusters/General/DiscoverCommandsGenerated.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/General/DiscoverCommandsGenerated.cs
@@ -44,13 +44,13 @@ namespace ZigBeeNet.ZCL.Clusters.General
             CommandDirection = ZclCommandDirection.CLIENT_TO_SERVER;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(StartCommandIdentifier, ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));
             serializer.Serialize(MaximumCommandIdentifiers, ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             StartCommandIdentifier = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));
             MaximumCommandIdentifiers = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));

--- a/src/ZigBeeNet/ZCL/Clusters/General/DiscoverCommandsGeneratedResponse.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/General/DiscoverCommandsGeneratedResponse.cs
@@ -44,13 +44,13 @@ namespace ZigBeeNet.ZCL.Clusters.General
             CommandDirection = ZclCommandDirection.CLIENT_TO_SERVER;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(DiscoveryComplete, ZclDataType.Get(DataType.BOOLEAN));
             serializer.Serialize(CommandIdentifiers, ZclDataType.Get(DataType.X_UNSIGNED_8_BIT_INTEGER));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             DiscoveryComplete = deserializer.Deserialize<bool>(ZclDataType.Get(DataType.BOOLEAN));
             CommandIdentifiers = deserializer.Deserialize<List<byte>>(ZclDataType.Get(DataType.X_UNSIGNED_8_BIT_INTEGER));

--- a/src/ZigBeeNet/ZCL/Clusters/General/DiscoverCommandsReceived.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/General/DiscoverCommandsReceived.cs
@@ -44,13 +44,13 @@ namespace ZigBeeNet.ZCL.Clusters.General
             CommandDirection = ZclCommandDirection.CLIENT_TO_SERVER;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(StartCommandIdentifier, ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));
             serializer.Serialize(MaximumCommandIdentifiers, ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             StartCommandIdentifier = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));
             MaximumCommandIdentifiers = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));

--- a/src/ZigBeeNet/ZCL/Clusters/General/DiscoverCommandsReceivedResponse.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/General/DiscoverCommandsReceivedResponse.cs
@@ -44,13 +44,13 @@ namespace ZigBeeNet.ZCL.Clusters.General
             CommandDirection = ZclCommandDirection.CLIENT_TO_SERVER;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(DiscoveryComplete, ZclDataType.Get(DataType.BOOLEAN));
             serializer.Serialize(CommandIdentifiers, ZclDataType.Get(DataType.X_UNSIGNED_8_BIT_INTEGER));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             DiscoveryComplete = deserializer.Deserialize<bool>(ZclDataType.Get(DataType.BOOLEAN));
             CommandIdentifiers = deserializer.Deserialize<List<byte>>(ZclDataType.Get(DataType.X_UNSIGNED_8_BIT_INTEGER));

--- a/src/ZigBeeNet/ZCL/Clusters/General/ReadAttributesCommand.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/General/ReadAttributesCommand.cs
@@ -40,12 +40,12 @@ namespace ZigBeeNet.ZCL.Clusters.General
             CommandDirection = ZclCommandDirection.CLIENT_TO_SERVER;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(Identifiers, ZclDataType.Get(DataType.N_X_ATTRIBUTE_IDENTIFIER));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             Identifiers = deserializer.Deserialize<List<ushort>>(ZclDataType.Get(DataType.N_X_ATTRIBUTE_IDENTIFIER));
         }

--- a/src/ZigBeeNet/ZCL/Clusters/General/ReadAttributesResponse.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/General/ReadAttributesResponse.cs
@@ -43,12 +43,12 @@ namespace ZigBeeNet.ZCL.Clusters.General
             CommandDirection = ZclCommandDirection.CLIENT_TO_SERVER;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(Records, ZclDataType.Get(DataType.N_X_READ_ATTRIBUTE_STATUS_RECORD));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             Records = deserializer.Deserialize<List<ReadAttributeStatusRecord>>(ZclDataType.Get(DataType.N_X_READ_ATTRIBUTE_STATUS_RECORD));
         }

--- a/src/ZigBeeNet/ZCL/Clusters/General/ReadAttributesStructuredCommand.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/General/ReadAttributesStructuredCommand.cs
@@ -41,12 +41,12 @@ namespace ZigBeeNet.ZCL.Clusters.General
             CommandDirection = ZclCommandDirection.CLIENT_TO_SERVER;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(AttributeSelectors, ZclDataType.Get(DataType.N_X_ATTRIBUTE_SELECTOR));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             AttributeSelectors = deserializer.Deserialize<object>(ZclDataType.Get(DataType.N_X_ATTRIBUTE_SELECTOR));
         }

--- a/src/ZigBeeNet/ZCL/Clusters/General/ReadReportingConfigurationCommand.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/General/ReadReportingConfigurationCommand.cs
@@ -39,12 +39,12 @@ namespace ZigBeeNet.ZCL.Clusters.General
             CommandDirection = ZclCommandDirection.CLIENT_TO_SERVER;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(Records, ZclDataType.Get(DataType.N_X_ATTRIBUTE_RECORD));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             Records = deserializer.Deserialize<List<AttributeRecord>>(ZclDataType.Get(DataType.N_X_ATTRIBUTE_RECORD));
         }

--- a/src/ZigBeeNet/ZCL/Clusters/General/ReadReportingConfigurationResponse.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/General/ReadReportingConfigurationResponse.cs
@@ -39,12 +39,12 @@ namespace ZigBeeNet.ZCL.Clusters.General
             CommandDirection = ZclCommandDirection.CLIENT_TO_SERVER;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(Records, ZclDataType.Get(DataType.N_X_ATTRIBUTE_REPORTING_CONFIGURATION_RECORD));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             Records = deserializer.Deserialize<List<AttributeReportingConfigurationRecord>>(ZclDataType.Get(DataType.N_X_ATTRIBUTE_REPORTING_CONFIGURATION_RECORD));
         }

--- a/src/ZigBeeNet/ZCL/Clusters/General/ReportAttributesCommand.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/General/ReportAttributesCommand.cs
@@ -41,12 +41,12 @@ namespace ZigBeeNet.ZCL.Clusters.General
             CommandDirection = ZclCommandDirection.CLIENT_TO_SERVER;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(Reports, ZclDataType.Get(DataType.N_X_ATTRIBUTE_REPORT));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             Reports = deserializer.Deserialize<List<AttributeReport>>(ZclDataType.Get(DataType.N_X_ATTRIBUTE_REPORT));
         }

--- a/src/ZigBeeNet/ZCL/Clusters/General/WriteAttributesCommand.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/General/WriteAttributesCommand.cs
@@ -41,12 +41,12 @@ namespace ZigBeeNet.ZCL.Clusters.General
             CommandDirection = ZclCommandDirection.CLIENT_TO_SERVER;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(Records, ZclDataType.Get(DataType.N_X_WRITE_ATTRIBUTE_RECORD));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             Records = deserializer.Deserialize<List<WriteAttributeRecord>>(ZclDataType.Get(DataType.N_X_WRITE_ATTRIBUTE_RECORD));
         }

--- a/src/ZigBeeNet/ZCL/Clusters/General/WriteAttributesNoResponse.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/General/WriteAttributesNoResponse.cs
@@ -41,12 +41,12 @@ namespace ZigBeeNet.ZCL.Clusters.General
             CommandDirection = ZclCommandDirection.CLIENT_TO_SERVER;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(Records, ZclDataType.Get(DataType.N_X_WRITE_ATTRIBUTE_RECORD));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             Records = deserializer.Deserialize<List<WriteAttributeRecord>>(ZclDataType.Get(DataType.N_X_WRITE_ATTRIBUTE_RECORD));
         }

--- a/src/ZigBeeNet/ZCL/Clusters/General/WriteAttributesResponse.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/General/WriteAttributesResponse.cs
@@ -39,12 +39,12 @@ namespace ZigBeeNet.ZCL.Clusters.General
             CommandDirection = ZclCommandDirection.CLIENT_TO_SERVER;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(Records, ZclDataType.Get(DataType.N_X_WRITE_ATTRIBUTE_STATUS_RECORD));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             Records = deserializer.Deserialize<List<WriteAttributeStatusRecord>>(ZclDataType.Get(DataType.N_X_WRITE_ATTRIBUTE_STATUS_RECORD));
         }

--- a/src/ZigBeeNet/ZCL/Clusters/General/WriteAttributesStructuredCommand.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/General/WriteAttributesStructuredCommand.cs
@@ -56,7 +56,7 @@ namespace ZigBeeNet.ZCL.Clusters.General
             CommandDirection = ZclCommandDirection.CLIENT_TO_SERVER;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             if (Status == ZclStatus.SUCCESS)
             {
@@ -66,7 +66,7 @@ namespace ZigBeeNet.ZCL.Clusters.General
             serializer.Serialize(AttributeSelectors, ZclDataType.Get(DataType.N_X_ATTRIBUTE_SELECTOR));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             if (deserializer.RemainingLength == 1)
             {

--- a/src/ZigBeeNet/ZCL/Clusters/General/WriteAttributesStructuredResponse.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/General/WriteAttributesStructuredResponse.cs
@@ -54,7 +54,7 @@ namespace ZigBeeNet.ZCL.Clusters.General
             CommandDirection = ZclCommandDirection.CLIENT_TO_SERVER;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             if (Status == ZclStatus.SUCCESS)
             {
@@ -64,7 +64,7 @@ namespace ZigBeeNet.ZCL.Clusters.General
             serializer.Serialize(Records, ZclDataType.Get(DataType.N_X_WRITE_ATTRIBUTE_STATUS_RECORD));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             if (deserializer.RemainingLength == 1)
             {

--- a/src/ZigBeeNet/ZCL/Clusters/General/WriteAttributesUndividedCommand.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/General/WriteAttributesUndividedCommand.cs
@@ -47,12 +47,12 @@ namespace ZigBeeNet.ZCL.Clusters.General
             CommandDirection = ZclCommandDirection.CLIENT_TO_SERVER;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(Records, ZclDataType.Get(DataType.N_X_WRITE_ATTRIBUTE_RECORD));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             Records = deserializer.Deserialize<List<WriteAttributeRecord>>(ZclDataType.Get(DataType.N_X_WRITE_ATTRIBUTE_RECORD));
         }

--- a/src/ZigBeeNet/ZCL/Clusters/Groups/AddGroupCommand.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/Groups/AddGroupCommand.cs
@@ -42,13 +42,13 @@ namespace ZigBeeNet.ZCL.Clusters.Groups
             CommandDirection = ZclCommandDirection.CLIENT_TO_SERVER;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(GroupID, ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));
             serializer.Serialize(GroupName, ZclDataType.Get(DataType.CHARACTER_STRING));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             GroupID = deserializer.Deserialize<ushort>(ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));
             GroupName = deserializer.Deserialize<string>(ZclDataType.Get(DataType.CHARACTER_STRING));

--- a/src/ZigBeeNet/ZCL/Clusters/Groups/AddGroupIfIdentifyingCommand.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/Groups/AddGroupIfIdentifyingCommand.cs
@@ -42,13 +42,13 @@ namespace ZigBeeNet.ZCL.Clusters.Groups
             CommandDirection = ZclCommandDirection.CLIENT_TO_SERVER;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(GroupID, ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));
             serializer.Serialize(GroupName, ZclDataType.Get(DataType.CHARACTER_STRING));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             GroupID = deserializer.Deserialize<ushort>(ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));
             GroupName = deserializer.Deserialize<string>(ZclDataType.Get(DataType.CHARACTER_STRING));

--- a/src/ZigBeeNet/ZCL/Clusters/Groups/AddGroupResponse.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/Groups/AddGroupResponse.cs
@@ -42,13 +42,13 @@ namespace ZigBeeNet.ZCL.Clusters.Groups
             CommandDirection = ZclCommandDirection.SERVER_TO_CLIENT;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(Status, ZclDataType.Get(DataType.ENUMERATION_8_BIT));
             serializer.Serialize(GroupID, ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             Status = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.ENUMERATION_8_BIT));
             GroupID = deserializer.Deserialize<ushort>(ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));

--- a/src/ZigBeeNet/ZCL/Clusters/Groups/GetGroupMembershipCommand.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/Groups/GetGroupMembershipCommand.cs
@@ -42,13 +42,13 @@ namespace ZigBeeNet.ZCL.Clusters.Groups
             CommandDirection = ZclCommandDirection.CLIENT_TO_SERVER;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(GroupCount, ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));
             serializer.Serialize(GroupList, ZclDataType.Get(DataType.N_X_UNSIGNED_16_BIT_INTEGER));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             GroupCount = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));
             GroupList = deserializer.Deserialize<List<ushort>>(ZclDataType.Get(DataType.N_X_UNSIGNED_16_BIT_INTEGER));

--- a/src/ZigBeeNet/ZCL/Clusters/Groups/GetGroupMembershipResponse.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/Groups/GetGroupMembershipResponse.cs
@@ -47,14 +47,14 @@ namespace ZigBeeNet.ZCL.Clusters.Groups
             CommandDirection = ZclCommandDirection.SERVER_TO_CLIENT;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(Capacity, ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));
             serializer.Serialize(GroupCount, ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));
             serializer.Serialize(GroupList, ZclDataType.Get(DataType.N_X_UNSIGNED_16_BIT_INTEGER));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             Capacity = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));
             GroupCount = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));

--- a/src/ZigBeeNet/ZCL/Clusters/Groups/RemoveGroupCommand.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/Groups/RemoveGroupCommand.cs
@@ -37,12 +37,12 @@ namespace ZigBeeNet.ZCL.Clusters.Groups
             CommandDirection = ZclCommandDirection.CLIENT_TO_SERVER;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(GroupID, ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             GroupID = deserializer.Deserialize<ushort>(ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));
         }

--- a/src/ZigBeeNet/ZCL/Clusters/Groups/RemoveGroupResponse.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/Groups/RemoveGroupResponse.cs
@@ -42,13 +42,13 @@ namespace ZigBeeNet.ZCL.Clusters.Groups
             CommandDirection = ZclCommandDirection.SERVER_TO_CLIENT;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(Status, ZclDataType.Get(DataType.ENUMERATION_8_BIT));
             serializer.Serialize(GroupID, ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             Status = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.ENUMERATION_8_BIT));
             GroupID = deserializer.Deserialize<ushort>(ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));

--- a/src/ZigBeeNet/ZCL/Clusters/Groups/ViewGroupCommand.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/Groups/ViewGroupCommand.cs
@@ -37,12 +37,12 @@ namespace ZigBeeNet.ZCL.Clusters.Groups
             CommandDirection = ZclCommandDirection.CLIENT_TO_SERVER;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(GroupID, ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             GroupID = deserializer.Deserialize<ushort>(ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));
         }

--- a/src/ZigBeeNet/ZCL/Clusters/Groups/ViewGroupResponse.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/Groups/ViewGroupResponse.cs
@@ -47,14 +47,14 @@ namespace ZigBeeNet.ZCL.Clusters.Groups
             CommandDirection = ZclCommandDirection.SERVER_TO_CLIENT;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(Status, ZclDataType.Get(DataType.ENUMERATION_8_BIT));
             serializer.Serialize(GroupID, ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));
             serializer.Serialize(GroupName, ZclDataType.Get(DataType.CHARACTER_STRING));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             Status = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.ENUMERATION_8_BIT));
             GroupID = deserializer.Deserialize<ushort>(ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));

--- a/src/ZigBeeNet/ZCL/Clusters/IASACE/ArmCommand.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/IASACE/ArmCommand.cs
@@ -66,14 +66,14 @@ namespace ZigBeeNet.ZCL.Clusters.IASACE
             CommandDirection = ZclCommandDirection.CLIENT_TO_SERVER;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(ArmMode, ZclDataType.Get(DataType.ENUMERATION_8_BIT));
             serializer.Serialize(ArmDisarmCode, ZclDataType.Get(DataType.CHARACTER_STRING));
             serializer.Serialize(ZoneID, ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             ArmMode = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.ENUMERATION_8_BIT));
             ArmDisarmCode = deserializer.Deserialize<string>(ZclDataType.Get(DataType.CHARACTER_STRING));

--- a/src/ZigBeeNet/ZCL/Clusters/IASACE/ArmResponse.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/IASACE/ArmResponse.cs
@@ -37,12 +37,12 @@ namespace ZigBeeNet.ZCL.Clusters.IASACE
             CommandDirection = ZclCommandDirection.SERVER_TO_CLIENT;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(ArmNotification, ZclDataType.Get(DataType.ENUMERATION_8_BIT));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             ArmNotification = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.ENUMERATION_8_BIT));
         }

--- a/src/ZigBeeNet/ZCL/Clusters/IASACE/BypassCommand.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/IASACE/BypassCommand.cs
@@ -60,14 +60,14 @@ namespace ZigBeeNet.ZCL.Clusters.IASACE
             CommandDirection = ZclCommandDirection.CLIENT_TO_SERVER;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(NumberOfZones, ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));
             serializer.Serialize(ZoneIDs, ZclDataType.Get(DataType.N_X_UNSIGNED_8_BIT_INTEGER));
             serializer.Serialize(ArmDisarmCode, ZclDataType.Get(DataType.CHARACTER_STRING));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             NumberOfZones = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));
             ZoneIDs = deserializer.Deserialize<List<byte>>(ZclDataType.Get(DataType.N_X_UNSIGNED_8_BIT_INTEGER));

--- a/src/ZigBeeNet/ZCL/Clusters/IASACE/BypassResponse.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/IASACE/BypassResponse.cs
@@ -43,12 +43,12 @@ namespace ZigBeeNet.ZCL.Clusters.IASACE
             CommandDirection = ZclCommandDirection.SERVER_TO_CLIENT;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(BypassResult, ZclDataType.Get(DataType.N_X_UNSIGNED_8_BIT_INTEGER));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             BypassResult = deserializer.Deserialize<List<byte>>(ZclDataType.Get(DataType.N_X_UNSIGNED_8_BIT_INTEGER));
         }

--- a/src/ZigBeeNet/ZCL/Clusters/IASACE/GetPanelStatusResponse.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/IASACE/GetPanelStatusResponse.cs
@@ -70,7 +70,7 @@ namespace ZigBeeNet.ZCL.Clusters.IASACE
             CommandDirection = ZclCommandDirection.SERVER_TO_CLIENT;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(PanelStatus, ZclDataType.Get(DataType.ENUMERATION_8_BIT));
             serializer.Serialize(SecondsRemaining, ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));
@@ -78,7 +78,7 @@ namespace ZigBeeNet.ZCL.Clusters.IASACE
             serializer.Serialize(AlarmStatus, ZclDataType.Get(DataType.ENUMERATION_8_BIT));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             PanelStatus = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.ENUMERATION_8_BIT));
             SecondsRemaining = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));

--- a/src/ZigBeeNet/ZCL/Clusters/IASACE/GetZoneIDMapResponse.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/IASACE/GetZoneIDMapResponse.cs
@@ -115,7 +115,7 @@ namespace ZigBeeNet.ZCL.Clusters.IASACE
             CommandDirection = ZclCommandDirection.SERVER_TO_CLIENT;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(ZoneIDMapSection0, ZclDataType.Get(DataType.BITMAP_16_BIT));
             serializer.Serialize(ZoneIDMapSection1, ZclDataType.Get(DataType.BITMAP_16_BIT));
@@ -135,7 +135,7 @@ namespace ZigBeeNet.ZCL.Clusters.IASACE
             serializer.Serialize(ZoneIDMapSection15, ZclDataType.Get(DataType.BITMAP_16_BIT));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             ZoneIDMapSection0 = deserializer.Deserialize<ushort>(ZclDataType.Get(DataType.BITMAP_16_BIT));
             ZoneIDMapSection1 = deserializer.Deserialize<ushort>(ZclDataType.Get(DataType.BITMAP_16_BIT));

--- a/src/ZigBeeNet/ZCL/Clusters/IASACE/GetZoneInformationCommand.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/IASACE/GetZoneInformationCommand.cs
@@ -37,12 +37,12 @@ namespace ZigBeeNet.ZCL.Clusters.IASACE
             CommandDirection = ZclCommandDirection.CLIENT_TO_SERVER;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(ZoneID, ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             ZoneID = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));
         }

--- a/src/ZigBeeNet/ZCL/Clusters/IASACE/GetZoneInformationResponse.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/IASACE/GetZoneInformationResponse.cs
@@ -58,7 +58,7 @@ namespace ZigBeeNet.ZCL.Clusters.IASACE
             CommandDirection = ZclCommandDirection.SERVER_TO_CLIENT;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(ZoneID, ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));
             serializer.Serialize(ZoneType, ZclDataType.Get(DataType.ENUMERATION_16_BIT));
@@ -66,7 +66,7 @@ namespace ZigBeeNet.ZCL.Clusters.IASACE
             serializer.Serialize(ZoneLabel, ZclDataType.Get(DataType.CHARACTER_STRING));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             ZoneID = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));
             ZoneType = deserializer.Deserialize<ushort>(ZclDataType.Get(DataType.ENUMERATION_16_BIT));

--- a/src/ZigBeeNet/ZCL/Clusters/IASACE/GetZoneStatusCommand.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/IASACE/GetZoneStatusCommand.cs
@@ -82,7 +82,7 @@ namespace ZigBeeNet.ZCL.Clusters.IASACE
             CommandDirection = ZclCommandDirection.CLIENT_TO_SERVER;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(StartingZoneID, ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));
             serializer.Serialize(MaxZoneIDs, ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));
@@ -90,7 +90,7 @@ namespace ZigBeeNet.ZCL.Clusters.IASACE
             serializer.Serialize(ZoneStatusMask, ZclDataType.Get(DataType.BITMAP_16_BIT));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             StartingZoneID = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));
             MaxZoneIDs = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));

--- a/src/ZigBeeNet/ZCL/Clusters/IASACE/GetZoneStatusResponse.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/IASACE/GetZoneStatusResponse.cs
@@ -68,7 +68,7 @@ namespace ZigBeeNet.ZCL.Clusters.IASACE
             CommandDirection = ZclCommandDirection.SERVER_TO_CLIENT;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(ZoneStatusComplete, ZclDataType.Get(DataType.BOOLEAN));
             serializer.Serialize(NumberOfZones, ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));
@@ -77,7 +77,7 @@ namespace ZigBeeNet.ZCL.Clusters.IASACE
             serializer.Serialize(ZoneStatus, ZclDataType.Get(DataType.BITMAP_16_BIT));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             ZoneStatusComplete = deserializer.Deserialize<bool>(ZclDataType.Get(DataType.BOOLEAN));
             NumberOfZones = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));

--- a/src/ZigBeeNet/ZCL/Clusters/IASACE/PanelStatusChangedCommand.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/IASACE/PanelStatusChangedCommand.cs
@@ -69,7 +69,7 @@ namespace ZigBeeNet.ZCL.Clusters.IASACE
             CommandDirection = ZclCommandDirection.SERVER_TO_CLIENT;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(PanelStatus, ZclDataType.Get(DataType.ENUMERATION_8_BIT));
             serializer.Serialize(SecondsRemaining, ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));
@@ -77,7 +77,7 @@ namespace ZigBeeNet.ZCL.Clusters.IASACE
             serializer.Serialize(AlarmStatus, ZclDataType.Get(DataType.ENUMERATION_8_BIT));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             PanelStatus = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.ENUMERATION_8_BIT));
             SecondsRemaining = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));

--- a/src/ZigBeeNet/ZCL/Clusters/IASACE/SetBypassedZoneListCommand.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/IASACE/SetBypassedZoneListCommand.cs
@@ -44,12 +44,12 @@ namespace ZigBeeNet.ZCL.Clusters.IASACE
             CommandDirection = ZclCommandDirection.SERVER_TO_CLIENT;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(ZoneID, ZclDataType.Get(DataType.N_X_UNSIGNED_8_BIT_INTEGER));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             ZoneID = deserializer.Deserialize<List<byte>>(ZclDataType.Get(DataType.N_X_UNSIGNED_8_BIT_INTEGER));
         }

--- a/src/ZigBeeNet/ZCL/Clusters/IASACE/ZoneStatusChangedCommand.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/IASACE/ZoneStatusChangedCommand.cs
@@ -63,7 +63,7 @@ namespace ZigBeeNet.ZCL.Clusters.IASACE
             CommandDirection = ZclCommandDirection.SERVER_TO_CLIENT;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(ZoneID, ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));
             serializer.Serialize(ZoneStatus, ZclDataType.Get(DataType.ENUMERATION_16_BIT));
@@ -71,7 +71,7 @@ namespace ZigBeeNet.ZCL.Clusters.IASACE
             serializer.Serialize(ZoneLabel, ZclDataType.Get(DataType.CHARACTER_STRING));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             ZoneID = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));
             ZoneStatus = deserializer.Deserialize<ushort>(ZclDataType.Get(DataType.ENUMERATION_16_BIT));

--- a/src/ZigBeeNet/ZCL/Clusters/IASWD/SquawkCommand.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/IASWD/SquawkCommand.cs
@@ -37,12 +37,12 @@ namespace ZigBeeNet.ZCL.Clusters.IASWD
             CommandDirection = ZclCommandDirection.CLIENT_TO_SERVER;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(Header, ZclDataType.Get(DataType.DATA_8_BIT));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             Header = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.DATA_8_BIT));
         }

--- a/src/ZigBeeNet/ZCL/Clusters/IASWD/StartWarningCommand.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/IASWD/StartWarningCommand.cs
@@ -48,13 +48,13 @@ namespace ZigBeeNet.ZCL.Clusters.IASWD
             CommandDirection = ZclCommandDirection.CLIENT_TO_SERVER;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(Header, ZclDataType.Get(DataType.DATA_8_BIT));
             serializer.Serialize(WarningDuration, ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             Header = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.DATA_8_BIT));
             WarningDuration = deserializer.Deserialize<ushort>(ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));

--- a/src/ZigBeeNet/ZCL/Clusters/IASZone/InitiateTestModeCommand.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/IASZone/InitiateTestModeCommand.cs
@@ -57,13 +57,13 @@ namespace ZigBeeNet.ZCL.Clusters.IASZone
             CommandDirection = ZclCommandDirection.CLIENT_TO_SERVER;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(TestModeDuration, ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));
             serializer.Serialize(CurrentZoneSensitivityLevel, ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             TestModeDuration = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));
             CurrentZoneSensitivityLevel = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));

--- a/src/ZigBeeNet/ZCL/Clusters/IASZone/ZoneEnrollRequestCommand.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/IASZone/ZoneEnrollRequestCommand.cs
@@ -46,13 +46,13 @@ namespace ZigBeeNet.ZCL.Clusters.IASZone
             CommandDirection = ZclCommandDirection.SERVER_TO_CLIENT;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(ZoneType, ZclDataType.Get(DataType.ENUMERATION_16_BIT));
             serializer.Serialize(ManufacturerCode, ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             ZoneType = deserializer.Deserialize<ushort>(ZclDataType.Get(DataType.ENUMERATION_16_BIT));
             ManufacturerCode = deserializer.Deserialize<ushort>(ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));

--- a/src/ZigBeeNet/ZCL/Clusters/IASZone/ZoneEnrollResponse.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/IASZone/ZoneEnrollResponse.cs
@@ -48,13 +48,13 @@ namespace ZigBeeNet.ZCL.Clusters.IASZone
             CommandDirection = ZclCommandDirection.CLIENT_TO_SERVER;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(EnrollResponseCode, ZclDataType.Get(DataType.ENUMERATION_8_BIT));
             serializer.Serialize(ZoneID, ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             EnrollResponseCode = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.ENUMERATION_8_BIT));
             ZoneID = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));

--- a/src/ZigBeeNet/ZCL/Clusters/IASZone/ZoneStatusChangeNotificationCommand.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/IASZone/ZoneStatusChangeNotificationCommand.cs
@@ -42,13 +42,13 @@ namespace ZigBeeNet.ZCL.Clusters.IASZone
             CommandDirection = ZclCommandDirection.SERVER_TO_CLIENT;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(ZoneStatus, ZclDataType.Get(DataType.ENUMERATION_16_BIT));
             serializer.Serialize(ExtendedStatus, ZclDataType.Get(DataType.ENUMERATION_8_BIT));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             ZoneStatus = deserializer.Deserialize<ushort>(ZclDataType.Get(DataType.ENUMERATION_16_BIT));
             ExtendedStatus = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.ENUMERATION_8_BIT));

--- a/src/ZigBeeNet/ZCL/Clusters/Identify/IdentifyCommand.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/Identify/IdentifyCommand.cs
@@ -39,12 +39,12 @@ namespace ZigBeeNet.ZCL.Clusters.Identify
             CommandDirection = ZclCommandDirection.CLIENT_TO_SERVER;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(IdentifyTime, ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             IdentifyTime = deserializer.Deserialize<ushort>(ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));
         }

--- a/src/ZigBeeNet/ZCL/Clusters/Identify/IdentifyQueryResponse.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/Identify/IdentifyQueryResponse.cs
@@ -40,12 +40,12 @@ namespace ZigBeeNet.ZCL.Clusters.Identify
             CommandDirection = ZclCommandDirection.SERVER_TO_CLIENT;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(IdentifyTime, ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             IdentifyTime = deserializer.Deserialize<ushort>(ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));
         }

--- a/src/ZigBeeNet/ZCL/Clusters/LevelControl/MoveCommand.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/LevelControl/MoveCommand.cs
@@ -42,13 +42,13 @@ namespace ZigBeeNet.ZCL.Clusters.LevelControl
             CommandDirection = ZclCommandDirection.CLIENT_TO_SERVER;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(MoveMode, ZclDataType.Get(DataType.ENUMERATION_8_BIT));
             serializer.Serialize(Rate, ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             MoveMode = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.ENUMERATION_8_BIT));
             Rate = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));

--- a/src/ZigBeeNet/ZCL/Clusters/LevelControl/MoveToLevelCommand.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/LevelControl/MoveToLevelCommand.cs
@@ -53,13 +53,13 @@ namespace ZigBeeNet.ZCL.Clusters.LevelControl
             CommandDirection = ZclCommandDirection.CLIENT_TO_SERVER;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(Level, ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));
             serializer.Serialize(TransitionTime, ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             Level = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));
             TransitionTime = deserializer.Deserialize<ushort>(ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));

--- a/src/ZigBeeNet/ZCL/Clusters/LevelControl/MoveToLevelWithOnOffCommand.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/LevelControl/MoveToLevelWithOnOffCommand.cs
@@ -42,13 +42,13 @@ namespace ZigBeeNet.ZCL.Clusters.LevelControl
             CommandDirection = ZclCommandDirection.CLIENT_TO_SERVER;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(Level, ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));
             serializer.Serialize(TransitionTime, ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             Level = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));
             TransitionTime = deserializer.Deserialize<ushort>(ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));

--- a/src/ZigBeeNet/ZCL/Clusters/LevelControl/MoveWithOnOffCommand.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/LevelControl/MoveWithOnOffCommand.cs
@@ -42,13 +42,13 @@ namespace ZigBeeNet.ZCL.Clusters.LevelControl
             CommandDirection = ZclCommandDirection.CLIENT_TO_SERVER;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(MoveMode, ZclDataType.Get(DataType.ENUMERATION_8_BIT));
             serializer.Serialize(Rate, ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             MoveMode = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.ENUMERATION_8_BIT));
             Rate = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));

--- a/src/ZigBeeNet/ZCL/Clusters/LevelControl/StepCommand.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/LevelControl/StepCommand.cs
@@ -47,14 +47,14 @@ namespace ZigBeeNet.ZCL.Clusters.LevelControl
             CommandDirection = ZclCommandDirection.CLIENT_TO_SERVER;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(StepMode, ZclDataType.Get(DataType.ENUMERATION_8_BIT));
             serializer.Serialize(StepSize, ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));
             serializer.Serialize(TransitionTime, ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             StepMode = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.ENUMERATION_8_BIT));
             StepSize = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));

--- a/src/ZigBeeNet/ZCL/Clusters/LevelControl/StepWithOnOffCommand.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/LevelControl/StepWithOnOffCommand.cs
@@ -47,14 +47,14 @@ namespace ZigBeeNet.ZCL.Clusters.LevelControl
             CommandDirection = ZclCommandDirection.CLIENT_TO_SERVER;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(StepMode, ZclDataType.Get(DataType.ENUMERATION_8_BIT));
             serializer.Serialize(StepSize, ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));
             serializer.Serialize(TransitionTime, ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             StepMode = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.ENUMERATION_8_BIT));
             StepSize = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));

--- a/src/ZigBeeNet/ZCL/Clusters/OTAUpgrade/ImageBlockCommand.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/OTAUpgrade/ImageBlockCommand.cs
@@ -87,7 +87,7 @@ namespace ZigBeeNet.ZCL.Clusters.OTAUpgrade
             CommandDirection = ZclCommandDirection.CLIENT_TO_SERVER;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(FieldControl, ZclDataType.Get(DataType.BITMAP_8_BIT));
             serializer.Serialize(ManufacturerCode, ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));
@@ -107,7 +107,7 @@ namespace ZigBeeNet.ZCL.Clusters.OTAUpgrade
             }
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             FieldControl = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.BITMAP_8_BIT));
             ManufacturerCode = deserializer.Deserialize<ushort>(ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));

--- a/src/ZigBeeNet/ZCL/Clusters/OTAUpgrade/ImageBlockResponse.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/OTAUpgrade/ImageBlockResponse.cs
@@ -81,7 +81,7 @@ namespace ZigBeeNet.ZCL.Clusters.OTAUpgrade
             CommandDirection = ZclCommandDirection.SERVER_TO_CLIENT;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(Status, ZclDataType.Get(DataType.ZCL_STATUS));
             serializer.Serialize(ManufacturerCode, ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));
@@ -91,7 +91,7 @@ namespace ZigBeeNet.ZCL.Clusters.OTAUpgrade
             serializer.Serialize(ImageData, ZclDataType.Get(DataType.BYTE_ARRAY));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             Status = deserializer.Deserialize<ZclStatus>(ZclDataType.Get(DataType.ZCL_STATUS));
             ManufacturerCode = deserializer.Deserialize<ushort>(ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));

--- a/src/ZigBeeNet/ZCL/Clusters/OTAUpgrade/ImageNotifyCommand.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/OTAUpgrade/ImageNotifyCommand.cs
@@ -72,7 +72,7 @@ namespace ZigBeeNet.ZCL.Clusters.OTAUpgrade
             CommandDirection = ZclCommandDirection.CLIENT_TO_SERVER;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(PayloadType, ZclDataType.Get(DataType.ENUMERATION_8_BIT));
 
@@ -97,7 +97,7 @@ namespace ZigBeeNet.ZCL.Clusters.OTAUpgrade
             }
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             PayloadType = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.ENUMERATION_8_BIT));
 

--- a/src/ZigBeeNet/ZCL/Clusters/OTAUpgrade/ImagePageCommand.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/OTAUpgrade/ImagePageCommand.cs
@@ -93,7 +93,7 @@ namespace ZigBeeNet.ZCL.Clusters.OTAUpgrade
             CommandDirection = ZclCommandDirection.CLIENT_TO_SERVER;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(FieldControl, ZclDataType.Get(DataType.BITMAP_8_BIT));
             serializer.Serialize(ManufacturerCode, ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));
@@ -110,7 +110,7 @@ namespace ZigBeeNet.ZCL.Clusters.OTAUpgrade
             }
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             FieldControl = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.BITMAP_8_BIT));
             ManufacturerCode = deserializer.Deserialize<ushort>(ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));

--- a/src/ZigBeeNet/ZCL/Clusters/OTAUpgrade/QueryNextImageCommand.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/OTAUpgrade/QueryNextImageCommand.cs
@@ -71,7 +71,7 @@ namespace ZigBeeNet.ZCL.Clusters.OTAUpgrade
             CommandDirection = ZclCommandDirection.CLIENT_TO_SERVER;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(FieldControl, ZclDataType.Get(DataType.BITMAP_8_BIT));
             serializer.Serialize(ManufacturerCode, ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));
@@ -84,7 +84,7 @@ namespace ZigBeeNet.ZCL.Clusters.OTAUpgrade
             }
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             FieldControl = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.BITMAP_8_BIT));
             ManufacturerCode = deserializer.Deserialize<ushort>(ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));

--- a/src/ZigBeeNet/ZCL/Clusters/OTAUpgrade/QueryNextImageResponse.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/OTAUpgrade/QueryNextImageResponse.cs
@@ -71,7 +71,7 @@ namespace ZigBeeNet.ZCL.Clusters.OTAUpgrade
             CommandDirection = ZclCommandDirection.SERVER_TO_CLIENT;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(Status, ZclDataType.Get(DataType.ZCL_STATUS));
 
@@ -96,7 +96,7 @@ namespace ZigBeeNet.ZCL.Clusters.OTAUpgrade
             }
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             Status = deserializer.Deserialize<ZclStatus>(ZclDataType.Get(DataType.ZCL_STATUS));
 

--- a/src/ZigBeeNet/ZCL/Clusters/OTAUpgrade/QuerySpecificFileCommand.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/OTAUpgrade/QuerySpecificFileCommand.cs
@@ -64,7 +64,7 @@ namespace ZigBeeNet.ZCL.Clusters.OTAUpgrade
             CommandDirection = ZclCommandDirection.CLIENT_TO_SERVER;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(RequestNodeAddress, ZclDataType.Get(DataType.IEEE_ADDRESS));
             serializer.Serialize(ManufacturerCode, ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));
@@ -73,7 +73,7 @@ namespace ZigBeeNet.ZCL.Clusters.OTAUpgrade
             serializer.Serialize(ZigbeeStackVersion, ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             RequestNodeAddress = deserializer.Deserialize<IeeeAddress>(ZclDataType.Get(DataType.IEEE_ADDRESS));
             ManufacturerCode = deserializer.Deserialize<ushort>(ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));

--- a/src/ZigBeeNet/ZCL/Clusters/OTAUpgrade/QuerySpecificFileResponse.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/OTAUpgrade/QuerySpecificFileResponse.cs
@@ -67,7 +67,7 @@ namespace ZigBeeNet.ZCL.Clusters.OTAUpgrade
             CommandDirection = ZclCommandDirection.SERVER_TO_CLIENT;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(Status, ZclDataType.Get(DataType.ZCL_STATUS));
 
@@ -92,7 +92,7 @@ namespace ZigBeeNet.ZCL.Clusters.OTAUpgrade
             }
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             Status = deserializer.Deserialize<ZclStatus>(ZclDataType.Get(DataType.ZCL_STATUS));
 

--- a/src/ZigBeeNet/ZCL/Clusters/OTAUpgrade/UpgradeEndCommand.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/OTAUpgrade/UpgradeEndCommand.cs
@@ -71,7 +71,7 @@ namespace ZigBeeNet.ZCL.Clusters.OTAUpgrade
             CommandDirection = ZclCommandDirection.CLIENT_TO_SERVER;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(Status, ZclDataType.Get(DataType.ZCL_STATUS));
             serializer.Serialize(ManufacturerCode, ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));
@@ -79,7 +79,7 @@ namespace ZigBeeNet.ZCL.Clusters.OTAUpgrade
             serializer.Serialize(FileVersion, ZclDataType.Get(DataType.UNSIGNED_32_BIT_INTEGER));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             Status = deserializer.Deserialize<ZclStatus>(ZclDataType.Get(DataType.ZCL_STATUS));
             ManufacturerCode = deserializer.Deserialize<ushort>(ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));

--- a/src/ZigBeeNet/ZCL/Clusters/OTAUpgrade/UpgradeEndResponse.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/OTAUpgrade/UpgradeEndResponse.cs
@@ -70,7 +70,7 @@ namespace ZigBeeNet.ZCL.Clusters.OTAUpgrade
             CommandDirection = ZclCommandDirection.SERVER_TO_CLIENT;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(ManufacturerCode, ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));
             serializer.Serialize(ImageType, ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));
@@ -79,7 +79,7 @@ namespace ZigBeeNet.ZCL.Clusters.OTAUpgrade
             serializer.Serialize(UpgradeTime, ZclDataType.Get(DataType.UNSIGNED_32_BIT_INTEGER));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             ManufacturerCode = deserializer.Deserialize<ushort>(ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));
             ImageType = deserializer.Deserialize<ushort>(ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));

--- a/src/ZigBeeNet/ZCL/Clusters/OnOff/OffWithEffectCommand.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/OnOff/OffWithEffectCommand.cs
@@ -44,13 +44,13 @@ namespace ZigBeeNet.ZCL.Clusters.OnOff
             CommandDirection = ZclCommandDirection.CLIENT_TO_SERVER;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(EffectIdentifier, ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));
             serializer.Serialize(EffectVariant, ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             EffectIdentifier = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));
             EffectVariant = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));

--- a/src/ZigBeeNet/ZCL/Clusters/OnOff/OnWithTimedOffCommand.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/OnOff/OnWithTimedOffCommand.cs
@@ -53,14 +53,14 @@ namespace ZigBeeNet.ZCL.Clusters.OnOff
             CommandDirection = ZclCommandDirection.CLIENT_TO_SERVER;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(OnOffControl, ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));
             serializer.Serialize(OnTime, ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));
             serializer.Serialize(OffWaitTime, ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             OnOffControl = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));
             OnTime = deserializer.Deserialize<ushort>(ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));

--- a/src/ZigBeeNet/ZCL/Clusters/PollControl/CheckInResponse.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/PollControl/CheckInResponse.cs
@@ -58,13 +58,13 @@ namespace ZigBeeNet.ZCL.Clusters.PollControl
             CommandDirection = ZclCommandDirection.CLIENT_TO_SERVER;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(StartFastPolling, ZclDataType.Get(DataType.BOOLEAN));
             serializer.Serialize(FastPollTimeout, ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             StartFastPolling = deserializer.Deserialize<bool>(ZclDataType.Get(DataType.BOOLEAN));
             FastPollTimeout = deserializer.Deserialize<ushort>(ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));

--- a/src/ZigBeeNet/ZCL/Clusters/PollControl/SetLongPollIntervalCommand.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/PollControl/SetLongPollIntervalCommand.cs
@@ -44,12 +44,12 @@ namespace ZigBeeNet.ZCL.Clusters.PollControl
             CommandDirection = ZclCommandDirection.CLIENT_TO_SERVER;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(NewLongPollInterval, ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             NewLongPollInterval = deserializer.Deserialize<ushort>(ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));
         }

--- a/src/ZigBeeNet/ZCL/Clusters/PollControl/SetShortPollIntervalCommand.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/PollControl/SetShortPollIntervalCommand.cs
@@ -44,12 +44,12 @@ namespace ZigBeeNet.ZCL.Clusters.PollControl
             CommandDirection = ZclCommandDirection.CLIENT_TO_SERVER;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(NewShortPollInterval, ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             NewShortPollInterval = deserializer.Deserialize<ushort>(ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));
         }

--- a/src/ZigBeeNet/ZCL/Clusters/RSSILocation/AnchorNodeAnnounceCommand.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/RSSILocation/AnchorNodeAnnounceCommand.cs
@@ -52,7 +52,7 @@ namespace ZigBeeNet.ZCL.Clusters.RSSILocation
             CommandDirection = ZclCommandDirection.CLIENT_TO_SERVER;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(AnchorNodeAddress, ZclDataType.Get(DataType.IEEE_ADDRESS));
             serializer.Serialize(Coordinate1, ZclDataType.Get(DataType.SIGNED_16_BIT_INTEGER));
@@ -60,7 +60,7 @@ namespace ZigBeeNet.ZCL.Clusters.RSSILocation
             serializer.Serialize(Coordinate3, ZclDataType.Get(DataType.SIGNED_16_BIT_INTEGER));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             AnchorNodeAddress = deserializer.Deserialize<IeeeAddress>(ZclDataType.Get(DataType.IEEE_ADDRESS));
             Coordinate1 = deserializer.Deserialize<short>(ZclDataType.Get(DataType.SIGNED_16_BIT_INTEGER));

--- a/src/ZigBeeNet/ZCL/Clusters/RSSILocation/DeviceConfigurationResponse.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/RSSILocation/DeviceConfigurationResponse.cs
@@ -62,7 +62,7 @@ namespace ZigBeeNet.ZCL.Clusters.RSSILocation
             CommandDirection = ZclCommandDirection.SERVER_TO_CLIENT;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(Status, ZclDataType.Get(DataType.ENUMERATION_8_BIT));
             serializer.Serialize(Power, ZclDataType.Get(DataType.SIGNED_16_BIT_INTEGER));
@@ -72,7 +72,7 @@ namespace ZigBeeNet.ZCL.Clusters.RSSILocation
             serializer.Serialize(ReportingPeriod, ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             Status = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.ENUMERATION_8_BIT));
             Power = deserializer.Deserialize<short>(ZclDataType.Get(DataType.SIGNED_16_BIT_INTEGER));

--- a/src/ZigBeeNet/ZCL/Clusters/RSSILocation/GetDeviceConfigurationCommand.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/RSSILocation/GetDeviceConfigurationCommand.cs
@@ -37,12 +37,12 @@ namespace ZigBeeNet.ZCL.Clusters.RSSILocation
             CommandDirection = ZclCommandDirection.CLIENT_TO_SERVER;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(TargetAddress, ZclDataType.Get(DataType.IEEE_ADDRESS));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             TargetAddress = deserializer.Deserialize<IeeeAddress>(ZclDataType.Get(DataType.IEEE_ADDRESS));
         }

--- a/src/ZigBeeNet/ZCL/Clusters/RSSILocation/GetLocationDataCommand.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/RSSILocation/GetLocationDataCommand.cs
@@ -47,14 +47,14 @@ namespace ZigBeeNet.ZCL.Clusters.RSSILocation
             CommandDirection = ZclCommandDirection.CLIENT_TO_SERVER;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(Header, ZclDataType.Get(DataType.BITMAP_8_BIT));
             serializer.Serialize(NumberResponses, ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));
             serializer.Serialize(TargetAddress, ZclDataType.Get(DataType.IEEE_ADDRESS));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             Header = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.BITMAP_8_BIT));
             NumberResponses = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));

--- a/src/ZigBeeNet/ZCL/Clusters/RSSILocation/LocationDataNotificationCommand.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/RSSILocation/LocationDataNotificationCommand.cs
@@ -77,7 +77,7 @@ namespace ZigBeeNet.ZCL.Clusters.RSSILocation
             CommandDirection = ZclCommandDirection.SERVER_TO_CLIENT;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(LocationType, ZclDataType.Get(DataType.DATA_8_BIT));
             serializer.Serialize(Coordinate1, ZclDataType.Get(DataType.SIGNED_16_BIT_INTEGER));
@@ -90,7 +90,7 @@ namespace ZigBeeNet.ZCL.Clusters.RSSILocation
             serializer.Serialize(LocationAge, ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             LocationType = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.DATA_8_BIT));
             Coordinate1 = deserializer.Deserialize<short>(ZclDataType.Get(DataType.SIGNED_16_BIT_INTEGER));

--- a/src/ZigBeeNet/ZCL/Clusters/RSSILocation/LocationDataResponse.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/RSSILocation/LocationDataResponse.cs
@@ -82,7 +82,7 @@ namespace ZigBeeNet.ZCL.Clusters.RSSILocation
             CommandDirection = ZclCommandDirection.SERVER_TO_CLIENT;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(Status, ZclDataType.Get(DataType.ENUMERATION_8_BIT));
             serializer.Serialize(LocationType, ZclDataType.Get(DataType.DATA_8_BIT));
@@ -96,7 +96,7 @@ namespace ZigBeeNet.ZCL.Clusters.RSSILocation
             serializer.Serialize(LocationAge, ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             Status = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.ENUMERATION_8_BIT));
             LocationType = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.DATA_8_BIT));

--- a/src/ZigBeeNet/ZCL/Clusters/RSSILocation/RSSIPingCommand.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/RSSILocation/RSSIPingCommand.cs
@@ -37,12 +37,12 @@ namespace ZigBeeNet.ZCL.Clusters.RSSILocation
             CommandDirection = ZclCommandDirection.SERVER_TO_CLIENT;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(LocationType, ZclDataType.Get(DataType.DATA_8_BIT));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             LocationType = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.DATA_8_BIT));
         }

--- a/src/ZigBeeNet/ZCL/Clusters/RSSILocation/RSSIResponse.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/RSSILocation/RSSIResponse.cs
@@ -62,7 +62,7 @@ namespace ZigBeeNet.ZCL.Clusters.RSSILocation
             CommandDirection = ZclCommandDirection.CLIENT_TO_SERVER;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(ReplyingDevice, ZclDataType.Get(DataType.IEEE_ADDRESS));
             serializer.Serialize(Coordinate1, ZclDataType.Get(DataType.SIGNED_16_BIT_INTEGER));
@@ -72,7 +72,7 @@ namespace ZigBeeNet.ZCL.Clusters.RSSILocation
             serializer.Serialize(NumberRSSIMeasurements, ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             ReplyingDevice = deserializer.Deserialize<IeeeAddress>(ZclDataType.Get(DataType.IEEE_ADDRESS));
             Coordinate1 = deserializer.Deserialize<short>(ZclDataType.Get(DataType.SIGNED_16_BIT_INTEGER));

--- a/src/ZigBeeNet/ZCL/Clusters/RSSILocation/ReportRSSIMeasurementsCommand.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/RSSILocation/ReportRSSIMeasurementsCommand.cs
@@ -47,14 +47,14 @@ namespace ZigBeeNet.ZCL.Clusters.RSSILocation
             CommandDirection = ZclCommandDirection.SERVER_TO_CLIENT;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(ReportingAddress, ZclDataType.Get(DataType.IEEE_ADDRESS));
             serializer.Serialize(NumberOfNeighbors, ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));
             serializer.Serialize(NeighborsInformation, ZclDataType.Get(DataType.N_X_NEIGHBORS_INFORMATION));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             ReportingAddress = deserializer.Deserialize<IeeeAddress>(ZclDataType.Get(DataType.IEEE_ADDRESS));
             NumberOfNeighbors = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));

--- a/src/ZigBeeNet/ZCL/Clusters/RSSILocation/RequestOwnLocationCommand.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/RSSILocation/RequestOwnLocationCommand.cs
@@ -37,12 +37,12 @@ namespace ZigBeeNet.ZCL.Clusters.RSSILocation
             CommandDirection = ZclCommandDirection.SERVER_TO_CLIENT;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(RequestingAddress, ZclDataType.Get(DataType.IEEE_ADDRESS));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             RequestingAddress = deserializer.Deserialize<IeeeAddress>(ZclDataType.Get(DataType.IEEE_ADDRESS));
         }

--- a/src/ZigBeeNet/ZCL/Clusters/RSSILocation/SendPingsCommand.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/RSSILocation/SendPingsCommand.cs
@@ -47,14 +47,14 @@ namespace ZigBeeNet.ZCL.Clusters.RSSILocation
             CommandDirection = ZclCommandDirection.CLIENT_TO_SERVER;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(TargetAddress, ZclDataType.Get(DataType.IEEE_ADDRESS));
             serializer.Serialize(NumberRSSIMeasurements, ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));
             serializer.Serialize(CalculationPeriod, ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             TargetAddress = deserializer.Deserialize<IeeeAddress>(ZclDataType.Get(DataType.IEEE_ADDRESS));
             NumberRSSIMeasurements = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));

--- a/src/ZigBeeNet/ZCL/Clusters/RSSILocation/SetAbsoluteLocationCommand.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/RSSILocation/SetAbsoluteLocationCommand.cs
@@ -57,7 +57,7 @@ namespace ZigBeeNet.ZCL.Clusters.RSSILocation
             CommandDirection = ZclCommandDirection.CLIENT_TO_SERVER;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(Coordinate1, ZclDataType.Get(DataType.SIGNED_16_BIT_INTEGER));
             serializer.Serialize(Coordinate2, ZclDataType.Get(DataType.SIGNED_16_BIT_INTEGER));
@@ -66,7 +66,7 @@ namespace ZigBeeNet.ZCL.Clusters.RSSILocation
             serializer.Serialize(PathLossExponent, ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             Coordinate1 = deserializer.Deserialize<short>(ZclDataType.Get(DataType.SIGNED_16_BIT_INTEGER));
             Coordinate2 = deserializer.Deserialize<short>(ZclDataType.Get(DataType.SIGNED_16_BIT_INTEGER));

--- a/src/ZigBeeNet/ZCL/Clusters/RSSILocation/SetDeviceConfigurationCommand.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/RSSILocation/SetDeviceConfigurationCommand.cs
@@ -57,7 +57,7 @@ namespace ZigBeeNet.ZCL.Clusters.RSSILocation
             CommandDirection = ZclCommandDirection.CLIENT_TO_SERVER;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(Power, ZclDataType.Get(DataType.SIGNED_16_BIT_INTEGER));
             serializer.Serialize(PathLossExponent, ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));
@@ -66,7 +66,7 @@ namespace ZigBeeNet.ZCL.Clusters.RSSILocation
             serializer.Serialize(ReportingPeriod, ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             Power = deserializer.Deserialize<short>(ZclDataType.Get(DataType.SIGNED_16_BIT_INTEGER));
             PathLossExponent = deserializer.Deserialize<ushort>(ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));

--- a/src/ZigBeeNet/ZCL/Clusters/Scenes/AddSceneCommand.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/Scenes/AddSceneCommand.cs
@@ -59,7 +59,7 @@ namespace ZigBeeNet.ZCL.Clusters.Scenes
             CommandDirection = ZclCommandDirection.CLIENT_TO_SERVER;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(GroupID, ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));
             serializer.Serialize(SceneID, ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));
@@ -68,7 +68,7 @@ namespace ZigBeeNet.ZCL.Clusters.Scenes
             serializer.Serialize(ExtensionFieldSets, ZclDataType.Get(DataType.N_X_EXTENSION_FIELD_SET));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             GroupID = deserializer.Deserialize<ushort>(ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));
             SceneID = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));

--- a/src/ZigBeeNet/ZCL/Clusters/Scenes/AddSceneResponse.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/Scenes/AddSceneResponse.cs
@@ -47,14 +47,14 @@ namespace ZigBeeNet.ZCL.Clusters.Scenes
             CommandDirection = ZclCommandDirection.SERVER_TO_CLIENT;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(Status, ZclDataType.Get(DataType.ENUMERATION_8_BIT));
             serializer.Serialize(GroupID, ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));
             serializer.Serialize(SceneID, ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             Status = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.ENUMERATION_8_BIT));
             GroupID = deserializer.Deserialize<ushort>(ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));

--- a/src/ZigBeeNet/ZCL/Clusters/Scenes/GetSceneMembershipCommand.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/Scenes/GetSceneMembershipCommand.cs
@@ -42,12 +42,12 @@ namespace ZigBeeNet.ZCL.Clusters.Scenes
             CommandDirection = ZclCommandDirection.CLIENT_TO_SERVER;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(GroupID, ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             GroupID = deserializer.Deserialize<ushort>(ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));
         }

--- a/src/ZigBeeNet/ZCL/Clusters/Scenes/GetSceneMembershipResponse.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/Scenes/GetSceneMembershipResponse.cs
@@ -57,7 +57,7 @@ namespace ZigBeeNet.ZCL.Clusters.Scenes
             CommandDirection = ZclCommandDirection.SERVER_TO_CLIENT;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(Status, ZclDataType.Get(DataType.ENUMERATION_8_BIT));
             serializer.Serialize(Capacity, ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));
@@ -66,7 +66,7 @@ namespace ZigBeeNet.ZCL.Clusters.Scenes
             serializer.Serialize(SceneList, ZclDataType.Get(DataType.N_X_UNSIGNED_8_BIT_INTEGER));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             Status = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.ENUMERATION_8_BIT));
             Capacity = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));

--- a/src/ZigBeeNet/ZCL/Clusters/Scenes/RecallSceneCommand.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/Scenes/RecallSceneCommand.cs
@@ -44,13 +44,13 @@ namespace ZigBeeNet.ZCL.Clusters.Scenes
             CommandDirection = ZclCommandDirection.CLIENT_TO_SERVER;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(GroupID, ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));
             serializer.Serialize(SceneID, ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             GroupID = deserializer.Deserialize<ushort>(ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));
             SceneID = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));

--- a/src/ZigBeeNet/ZCL/Clusters/Scenes/RemoveAllScenesCommand.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/Scenes/RemoveAllScenesCommand.cs
@@ -39,12 +39,12 @@ namespace ZigBeeNet.ZCL.Clusters.Scenes
             CommandDirection = ZclCommandDirection.CLIENT_TO_SERVER;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(GroupID, ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             GroupID = deserializer.Deserialize<ushort>(ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));
         }

--- a/src/ZigBeeNet/ZCL/Clusters/Scenes/RemoveAllScenesResponse.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/Scenes/RemoveAllScenesResponse.cs
@@ -42,13 +42,13 @@ namespace ZigBeeNet.ZCL.Clusters.Scenes
             CommandDirection = ZclCommandDirection.SERVER_TO_CLIENT;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(Status, ZclDataType.Get(DataType.ENUMERATION_8_BIT));
             serializer.Serialize(GroupID, ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             Status = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.ENUMERATION_8_BIT));
             GroupID = deserializer.Deserialize<ushort>(ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));

--- a/src/ZigBeeNet/ZCL/Clusters/Scenes/RemoveSceneCommand.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/Scenes/RemoveSceneCommand.cs
@@ -44,13 +44,13 @@ namespace ZigBeeNet.ZCL.Clusters.Scenes
             CommandDirection = ZclCommandDirection.CLIENT_TO_SERVER;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(GroupID, ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));
             serializer.Serialize(SceneID, ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             GroupID = deserializer.Deserialize<ushort>(ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));
             SceneID = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));

--- a/src/ZigBeeNet/ZCL/Clusters/Scenes/RemoveSceneResponse.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/Scenes/RemoveSceneResponse.cs
@@ -47,14 +47,14 @@ namespace ZigBeeNet.ZCL.Clusters.Scenes
             CommandDirection = ZclCommandDirection.SERVER_TO_CLIENT;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(Status, ZclDataType.Get(DataType.ENUMERATION_8_BIT));
             serializer.Serialize(GroupID, ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));
             serializer.Serialize(SceneID, ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             Status = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.ENUMERATION_8_BIT));
             GroupID = deserializer.Deserialize<ushort>(ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));

--- a/src/ZigBeeNet/ZCL/Clusters/Scenes/StoreSceneCommand.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/Scenes/StoreSceneCommand.cs
@@ -44,13 +44,13 @@ namespace ZigBeeNet.ZCL.Clusters.Scenes
             CommandDirection = ZclCommandDirection.CLIENT_TO_SERVER;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(GroupID, ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));
             serializer.Serialize(SceneID, ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             GroupID = deserializer.Deserialize<ushort>(ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));
             SceneID = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));

--- a/src/ZigBeeNet/ZCL/Clusters/Scenes/StoreSceneResponse.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/Scenes/StoreSceneResponse.cs
@@ -47,14 +47,14 @@ namespace ZigBeeNet.ZCL.Clusters.Scenes
             CommandDirection = ZclCommandDirection.SERVER_TO_CLIENT;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(Status, ZclDataType.Get(DataType.ENUMERATION_8_BIT));
             serializer.Serialize(GroupID, ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));
             serializer.Serialize(SceneID, ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             Status = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.ENUMERATION_8_BIT));
             GroupID = deserializer.Deserialize<ushort>(ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));

--- a/src/ZigBeeNet/ZCL/Clusters/Scenes/ViewSceneCommand.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/Scenes/ViewSceneCommand.cs
@@ -44,13 +44,13 @@ namespace ZigBeeNet.ZCL.Clusters.Scenes
             CommandDirection = ZclCommandDirection.CLIENT_TO_SERVER;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(GroupID, ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));
             serializer.Serialize(SceneID, ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             GroupID = deserializer.Deserialize<ushort>(ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));
             SceneID = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));

--- a/src/ZigBeeNet/ZCL/Clusters/Scenes/ViewSceneResponse.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/Scenes/ViewSceneResponse.cs
@@ -62,7 +62,7 @@ namespace ZigBeeNet.ZCL.Clusters.Scenes
             CommandDirection = ZclCommandDirection.SERVER_TO_CLIENT;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(Status, ZclDataType.Get(DataType.ENUMERATION_8_BIT));
             serializer.Serialize(GroupID, ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));
@@ -72,7 +72,7 @@ namespace ZigBeeNet.ZCL.Clusters.Scenes
             serializer.Serialize(ExtensionFieldSets, ZclDataType.Get(DataType.N_X_EXTENSION_FIELD_SET));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             Status = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.ENUMERATION_8_BIT));
             GroupID = deserializer.Deserialize<ushort>(ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));

--- a/src/ZigBeeNet/ZCL/Clusters/Thermostat/GetRelayStatusLogResponse.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/Thermostat/GetRelayStatusLogResponse.cs
@@ -62,7 +62,7 @@ namespace ZigBeeNet.ZCL.Clusters.Thermostat
             CommandDirection = ZclCommandDirection.SERVER_TO_CLIENT;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(TimeOfDay, ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));
             serializer.Serialize(RelayStatus, ZclDataType.Get(DataType.BITMAP_8_BIT));
@@ -72,7 +72,7 @@ namespace ZigBeeNet.ZCL.Clusters.Thermostat
             serializer.Serialize(UnreadEntries, ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             TimeOfDay = deserializer.Deserialize<ushort>(ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));
             RelayStatus = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.BITMAP_8_BIT));

--- a/src/ZigBeeNet/ZCL/Clusters/Thermostat/GetWeeklySchedule.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/Thermostat/GetWeeklySchedule.cs
@@ -42,13 +42,13 @@ namespace ZigBeeNet.ZCL.Clusters.Thermostat
             CommandDirection = ZclCommandDirection.CLIENT_TO_SERVER;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(DaysToReturn, ZclDataType.Get(DataType.BITMAP_8_BIT));
             serializer.Serialize(ModeToReturn, ZclDataType.Get(DataType.BITMAP_8_BIT));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             DaysToReturn = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.BITMAP_8_BIT));
             ModeToReturn = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.BITMAP_8_BIT));

--- a/src/ZigBeeNet/ZCL/Clusters/Thermostat/GetWeeklyScheduleResponse.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/Thermostat/GetWeeklyScheduleResponse.cs
@@ -62,7 +62,7 @@ namespace ZigBeeNet.ZCL.Clusters.Thermostat
             CommandDirection = ZclCommandDirection.SERVER_TO_CLIENT;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(NumberOfTransitions, ZclDataType.Get(DataType.ENUMERATION_8_BIT));
             serializer.Serialize(DayOfWeek, ZclDataType.Get(DataType.ENUMERATION_8_BIT));
@@ -72,7 +72,7 @@ namespace ZigBeeNet.ZCL.Clusters.Thermostat
             serializer.Serialize(CoolSet, ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             NumberOfTransitions = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.ENUMERATION_8_BIT));
             DayOfWeek = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.ENUMERATION_8_BIT));

--- a/src/ZigBeeNet/ZCL/Clusters/Thermostat/SetWeeklySchedule.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/Thermostat/SetWeeklySchedule.cs
@@ -71,7 +71,7 @@ namespace ZigBeeNet.ZCL.Clusters.Thermostat
             CommandDirection = ZclCommandDirection.CLIENT_TO_SERVER;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(NumberOfTransitions, ZclDataType.Get(DataType.ENUMERATION_8_BIT));
             serializer.Serialize(DayOfWeek, ZclDataType.Get(DataType.ENUMERATION_8_BIT));
@@ -81,7 +81,7 @@ namespace ZigBeeNet.ZCL.Clusters.Thermostat
             serializer.Serialize(CoolSet, ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             NumberOfTransitions = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.ENUMERATION_8_BIT));
             DayOfWeek = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.ENUMERATION_8_BIT));

--- a/src/ZigBeeNet/ZCL/Clusters/Thermostat/SetpointRaiseLowerCommand.cs
+++ b/src/ZigBeeNet/ZCL/Clusters/Thermostat/SetpointRaiseLowerCommand.cs
@@ -42,13 +42,13 @@ namespace ZigBeeNet.ZCL.Clusters.Thermostat
             CommandDirection = ZclCommandDirection.CLIENT_TO_SERVER;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize(Mode, ZclDataType.Get(DataType.ENUMERATION_8_BIT));
             serializer.Serialize(Amount, ZclDataType.Get(DataType.SIGNED_8_BIT_INTEGER));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             Mode = deserializer.Deserialize<byte>(ZclDataType.Get(DataType.ENUMERATION_8_BIT));
             Amount = deserializer.Deserialize<sbyte>(ZclDataType.Get(DataType.SIGNED_8_BIT_INTEGER));

--- a/src/ZigBeeNet/ZCL/ZclCommand.cs
+++ b/src/ZigBeeNet/ZCL/ZclCommand.cs
@@ -1,32 +1,27 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Text;
+﻿using System.Text;
 using ZigBeeNet.ZCL.Protocol;
 
 namespace ZigBeeNet.ZCL
 {
     public abstract class ZclCommand : ZigBeeCommand
     {
+        /// <summary>
+        /// True if this is a generic command
+        /// </summary>
+        internal bool GenericCommand { get; set; }
 
         /// <summary>
-         /// True if this is a generic command
-         /// </summary>
-        public bool GenericCommand { get; set; }
+        /// The command ID
+        /// </summary>
+        internal byte CommandId { get; set; }
 
         /// <summary>
-         /// The command ID
-         /// </summary>
-        public byte CommandId { get; set; }
-
-        /// <summary>
-         /// The command direction for this command.
-         /// <p>
-         /// If this command is to be sent <b>to</b> the server, this will return <i>true</i>.
-         /// If this command is to be sent <b>from</b> the server, this will return <i>false</i>.
-         /// </summary>
-        public ZclCommandDirection CommandDirection { get; set; }
-
+        /// The command direction for this command.
+        /// <p>
+        /// If this command is to be sent <b>to</b> the server, this will return <i>true</i>.
+        /// If this command is to be sent <b>from</b> the server, this will return <i>false</i>.
+        /// </summary>
+        internal ZclCommandDirection CommandDirection { get; set; }
 
         public override string ToString()
         {

--- a/src/ZigBeeNet/ZDO/Command/ActiveEndpointsRequest.cs
+++ b/src/ZigBeeNet/ZDO/Command/ActiveEndpointsRequest.cs
@@ -31,14 +31,14 @@ namespace ZigBeeNet.ZDO.Command
         }
 
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             base.Serialize(serializer);
 
             serializer.Serialize(NwkAddrOfInterest, ZclDataType.Get(DataType.NWK_ADDRESS));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             base.Deserialize(deserializer);
 

--- a/src/ZigBeeNet/ZDO/Command/ActiveEndpointsResponse.cs
+++ b/src/ZigBeeNet/ZDO/Command/ActiveEndpointsResponse.cs
@@ -33,7 +33,7 @@ namespace ZigBeeNet.ZDO.Command
             ClusterId = 0x8005;
         }
        
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             base.Serialize(serializer);
 
@@ -47,7 +47,7 @@ namespace ZigBeeNet.ZDO.Command
             }
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             base.Deserialize(deserializer);
 

--- a/src/ZigBeeNet/ZDO/Command/BackupBindTableResponse.cs
+++ b/src/ZigBeeNet/ZDO/Command/BackupBindTableResponse.cs
@@ -33,14 +33,14 @@ namespace ZigBeeNet.ZDO.Command
             ClusterId = 0x8027;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             base.Serialize(serializer);
 
             serializer.Serialize(Status, ZclDataType.Get(DataType.ZDO_STATUS));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             base.Deserialize(deserializer);
 

--- a/src/ZigBeeNet/ZDO/Command/BackupSourceBindRequest.cs
+++ b/src/ZigBeeNet/ZDO/Command/BackupSourceBindRequest.cs
@@ -45,7 +45,7 @@ namespace ZigBeeNet.ZDO.Command
             ClusterId = 0x0029;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             base.Serialize(serializer);
 
@@ -55,7 +55,7 @@ namespace ZigBeeNet.ZDO.Command
             serializer.Serialize(SourceTableList, ZclDataType.Get(DataType.N_X_IEEE_ADDRESS));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             base.Deserialize(deserializer);
 

--- a/src/ZigBeeNet/ZDO/Command/BindRegisterResponse.cs
+++ b/src/ZigBeeNet/ZDO/Command/BindRegisterResponse.cs
@@ -36,7 +36,7 @@ namespace ZigBeeNet.ZDO.Command
         }
 
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             base.Serialize(serializer);
 
@@ -50,7 +50,7 @@ namespace ZigBeeNet.ZDO.Command
             }
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             base.Deserialize(deserializer);
 

--- a/src/ZigBeeNet/ZDO/Command/BindRequest.cs
+++ b/src/ZigBeeNet/ZDO/Command/BindRequest.cs
@@ -76,7 +76,7 @@ namespace ZigBeeNet.ZDO.Command
             ClusterId = 0x0021;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             base.Serialize(serializer);
 
@@ -88,7 +88,7 @@ namespace ZigBeeNet.ZDO.Command
             serializer.Serialize(DstEndpoint, ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             base.Deserialize(deserializer);
 

--- a/src/ZigBeeNet/ZDO/Command/BindResponse.cs
+++ b/src/ZigBeeNet/ZDO/Command/BindResponse.cs
@@ -30,7 +30,7 @@ namespace ZigBeeNet.ZDO.Command
             ClusterId = 0x8021;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             base.Serialize(serializer);
 
@@ -38,7 +38,7 @@ namespace ZigBeeNet.ZDO.Command
         }
 
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             base.Deserialize(deserializer);
 

--- a/src/ZigBeeNet/ZDO/Command/ComplexDescriptorRequest.cs
+++ b/src/ZigBeeNet/ZDO/Command/ComplexDescriptorRequest.cs
@@ -30,14 +30,14 @@ namespace ZigBeeNet.ZDO.Command
             ClusterId = 0x0010;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             base.Serialize(serializer);
 
             serializer.Serialize(NwkAddrOfInterest, ZclDataType.Get(DataType.NWK_ADDRESS));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             base.Deserialize(deserializer);
 

--- a/src/ZigBeeNet/ZDO/Command/ComplexDescriptorResponse.cs
+++ b/src/ZigBeeNet/ZDO/Command/ComplexDescriptorResponse.cs
@@ -40,7 +40,7 @@ namespace ZigBeeNet.ZDO.Command
             ClusterId = 0x8010;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             base.Serialize(serializer);
 
@@ -50,7 +50,7 @@ namespace ZigBeeNet.ZDO.Command
             serializer.Serialize(ComplexDescriptor, ZclDataType.Get(DataType.COMPLEX_DESCRIPTOR));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             base.Deserialize(deserializer);
 

--- a/src/ZigBeeNet/ZDO/Command/DeviceAnnounce.cs
+++ b/src/ZigBeeNet/ZDO/Command/DeviceAnnounce.cs
@@ -44,7 +44,7 @@ namespace ZigBeeNet.ZDO.Command
             ClusterId = 0x0013;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             base.Serialize(serializer);
 
@@ -53,7 +53,7 @@ namespace ZigBeeNet.ZDO.Command
             serializer.Serialize(Capability, ZclDataType.Get(DataType.BITMAP_8_BIT));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             base.Deserialize(deserializer);
 

--- a/src/ZigBeeNet/ZDO/Command/EndDeviceBindRequest.cs
+++ b/src/ZigBeeNet/ZDO/Command/EndDeviceBindRequest.cs
@@ -57,7 +57,7 @@ namespace ZigBeeNet.ZDO.Command
             ClusterId = 0x0020;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             base.Serialize(serializer);
 
@@ -80,7 +80,7 @@ namespace ZigBeeNet.ZDO.Command
             }
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             base.Deserialize(deserializer);
 

--- a/src/ZigBeeNet/ZDO/Command/EndDeviceBindResponse.cs
+++ b/src/ZigBeeNet/ZDO/Command/EndDeviceBindResponse.cs
@@ -25,14 +25,14 @@ namespace ZigBeeNet.ZDO.Command
             ClusterId = 0x8020;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             base.Serialize(serializer);
 
             serializer.Serialize(Status, ZclDataType.Get(DataType.ZDO_STATUS));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             base.Deserialize(deserializer);
 

--- a/src/ZigBeeNet/ZDO/Command/ExtendedSimpleDescriptorRequest.cs
+++ b/src/ZigBeeNet/ZDO/Command/ExtendedSimpleDescriptorRequest.cs
@@ -43,7 +43,7 @@ namespace ZigBeeNet.ZDO.Command
             ClusterId = 0x001D;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             base.Serialize(serializer);
 
@@ -52,7 +52,7 @@ namespace ZigBeeNet.ZDO.Command
             serializer.Serialize(StartIndex, ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             base.Deserialize(deserializer);
 

--- a/src/ZigBeeNet/ZDO/Command/IeeeAddressRequest.cs
+++ b/src/ZigBeeNet/ZDO/Command/IeeeAddressRequest.cs
@@ -32,7 +32,7 @@ namespace ZigBeeNet.ZDO.Command
             ClusterId = 0x0001;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             base.Serialize(serializer);
 
@@ -41,7 +41,7 @@ namespace ZigBeeNet.ZDO.Command
             serializer.Serialize(StartIndex, ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             base.Deserialize(deserializer);
 

--- a/src/ZigBeeNet/ZDO/Command/IeeeAddressResponse.cs
+++ b/src/ZigBeeNet/ZDO/Command/IeeeAddressResponse.cs
@@ -45,7 +45,7 @@ namespace ZigBeeNet.ZDO.Command
             ClusterId = 0x8001;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             base.Serialize(serializer);
 
@@ -60,7 +60,7 @@ namespace ZigBeeNet.ZDO.Command
                 serializer.Serialize(NwkAddrAssocDevList[cnt], ZclDataType.Get(DataType.NWK_ADDRESS));
             }
         }
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
 
         {
             base.Deserialize(deserializer);

--- a/src/ZigBeeNet/ZDO/Command/ManagementBindRequest.cs
+++ b/src/ZigBeeNet/ZDO/Command/ManagementBindRequest.cs
@@ -33,14 +33,14 @@ namespace ZigBeeNet.ZDO.Command
             ClusterId = 0x0033;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             base.Serialize(serializer);
 
             serializer.Serialize(StartIndex, ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             base.Deserialize(deserializer);
 

--- a/src/ZigBeeNet/ZDO/Command/ManagementBindResponse.cs
+++ b/src/ZigBeeNet/ZDO/Command/ManagementBindResponse.cs
@@ -42,7 +42,7 @@ namespace ZigBeeNet.ZDO.Command
         }
 
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             base.Serialize(serializer);
 
@@ -56,7 +56,7 @@ namespace ZigBeeNet.ZDO.Command
             }
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             base.Deserialize(deserializer);
 

--- a/src/ZigBeeNet/ZDO/Command/ManagementDirectJoinRequest.cs
+++ b/src/ZigBeeNet/ZDO/Command/ManagementDirectJoinRequest.cs
@@ -77,7 +77,7 @@ namespace ZigBeeNet.ZDO.Command
             this.CapabilityInformation = capabilityInformation;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             base.Serialize(serializer);
 
@@ -85,7 +85,7 @@ namespace ZigBeeNet.ZDO.Command
             serializer.Serialize(CapabilityInformation, ZclDataType.Get(DataType.BITMAP_8_BIT));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             base.Deserialize(deserializer);
 

--- a/src/ZigBeeNet/ZDO/Command/ManagementDirectJoinResponse.cs
+++ b/src/ZigBeeNet/ZDO/Command/ManagementDirectJoinResponse.cs
@@ -25,14 +25,14 @@ namespace ZigBeeNet.ZDO.Command
             ClusterId = 0x8035;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             base.Serialize(serializer);
 
             serializer.Serialize(Status, ZclDataType.Get(DataType.ZDO_STATUS));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             base.Deserialize(deserializer);
 

--- a/src/ZigBeeNet/ZDO/Command/ManagementLeaveRequest.cs
+++ b/src/ZigBeeNet/ZDO/Command/ManagementLeaveRequest.cs
@@ -77,7 +77,7 @@ namespace ZigBeeNet.ZDO.Command
             this.RemoveChildrenRejoin = removeChildrenRejoin;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             base.Serialize(serializer);
 
@@ -85,7 +85,7 @@ namespace ZigBeeNet.ZDO.Command
             serializer.Serialize(RemoveChildrenRejoin, ZclDataType.Get(DataType.BOOLEAN));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             base.Deserialize(deserializer);
 

--- a/src/ZigBeeNet/ZDO/Command/ManagementLeaveResponse.cs
+++ b/src/ZigBeeNet/ZDO/Command/ManagementLeaveResponse.cs
@@ -33,14 +33,14 @@ namespace ZigBeeNet.ZDO.Command
             ClusterId = 0x8034;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             base.Serialize(serializer);
 
             serializer.Serialize(Status, ZclDataType.Get(DataType.ZDO_STATUS));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             base.Deserialize(deserializer);
 

--- a/src/ZigBeeNet/ZDO/Command/ManagementLqiRequest.cs
+++ b/src/ZigBeeNet/ZDO/Command/ManagementLqiRequest.cs
@@ -30,14 +30,14 @@ namespace ZigBeeNet.ZDO.Command
             ClusterId = 0x0031;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             base.Serialize(serializer);
 
             serializer.Serialize(StartIndex, ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             base.Deserialize(deserializer);
 

--- a/src/ZigBeeNet/ZDO/Command/ManagementLqiResponse.cs
+++ b/src/ZigBeeNet/ZDO/Command/ManagementLqiResponse.cs
@@ -40,7 +40,7 @@ namespace ZigBeeNet.ZDO.Command
             ClusterId = 0x8031;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             base.Serialize(serializer);
 
@@ -55,7 +55,7 @@ namespace ZigBeeNet.ZDO.Command
             }
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             base.Deserialize(deserializer);
 

--- a/src/ZigBeeNet/ZDO/Command/ManagementNetworkDiscovery.cs
+++ b/src/ZigBeeNet/ZDO/Command/ManagementNetworkDiscovery.cs
@@ -39,7 +39,7 @@ namespace ZigBeeNet.ZDO.Command
             ClusterId = 0x0030;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             base.Serialize(serializer);
 
@@ -48,7 +48,7 @@ namespace ZigBeeNet.ZDO.Command
             serializer.Serialize(StartIndex, ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             base.Deserialize(deserializer);
 

--- a/src/ZigBeeNet/ZDO/Command/ManagementNetworkUpdateNotify.cs
+++ b/src/ZigBeeNet/ZDO/Command/ManagementNetworkUpdateNotify.cs
@@ -57,7 +57,7 @@ namespace ZigBeeNet.ZDO.Command
         }
 
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             base.Serialize(serializer);
 
@@ -73,7 +73,7 @@ namespace ZigBeeNet.ZDO.Command
             }
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             base.Deserialize(deserializer);
 

--- a/src/ZigBeeNet/ZDO/Command/ManagementPermitJoiningRequest.cs
+++ b/src/ZigBeeNet/ZDO/Command/ManagementPermitJoiningRequest.cs
@@ -42,7 +42,7 @@ namespace ZigBeeNet.ZDO.Command
             ClusterId = 0x0036;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             base.Serialize(serializer);
 
@@ -50,7 +50,7 @@ namespace ZigBeeNet.ZDO.Command
             serializer.Serialize(TcSignificance, ZclDataType.Get(DataType.BOOLEAN));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             base.Deserialize(deserializer);
 

--- a/src/ZigBeeNet/ZDO/Command/ManagementPermitJoiningResponse.cs
+++ b/src/ZigBeeNet/ZDO/Command/ManagementPermitJoiningResponse.cs
@@ -30,14 +30,14 @@ namespace ZigBeeNet.ZDO.Command
             ClusterId = 0x8036;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             base.Serialize(serializer);
 
             serializer.Serialize(Status, ZclDataType.Get(DataType.ZDO_STATUS));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             base.Deserialize(deserializer);
 

--- a/src/ZigBeeNet/ZDO/Command/ManagementRoutingRequest.cs
+++ b/src/ZigBeeNet/ZDO/Command/ManagementRoutingRequest.cs
@@ -30,14 +30,14 @@ namespace ZigBeeNet.ZDO.Command
             ClusterId = 0x0032;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             base.Serialize(serializer);
 
             serializer.Serialize(StartIndex, ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             base.Deserialize(deserializer);
 

--- a/src/ZigBeeNet/ZDO/Command/ManagementRoutingResponse.cs
+++ b/src/ZigBeeNet/ZDO/Command/ManagementRoutingResponse.cs
@@ -40,7 +40,7 @@ namespace ZigBeeNet.ZDO.Command
             ClusterId = 0x8032;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             base.Serialize(serializer);
 
@@ -55,7 +55,7 @@ namespace ZigBeeNet.ZDO.Command
             }
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             base.Deserialize(deserializer);
 

--- a/src/ZigBeeNet/ZDO/Command/MatchDescriptorRequest.cs
+++ b/src/ZigBeeNet/ZDO/Command/MatchDescriptorRequest.cs
@@ -48,7 +48,7 @@ namespace ZigBeeNet.ZDO.Command
             ClusterId = 0x0006;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             base.Serialize(serializer);
 
@@ -69,7 +69,7 @@ namespace ZigBeeNet.ZDO.Command
             }
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             base.Deserialize(deserializer);
 

--- a/src/ZigBeeNet/ZDO/Command/MatchDescriptorResponse.cs
+++ b/src/ZigBeeNet/ZDO/Command/MatchDescriptorResponse.cs
@@ -36,7 +36,7 @@ namespace ZigBeeNet.ZDO.Command
         }
 
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             base.Serialize(serializer);
 
@@ -50,7 +50,7 @@ namespace ZigBeeNet.ZDO.Command
             }
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             base.Deserialize(deserializer);
 

--- a/src/ZigBeeNet/ZDO/Command/NetworkAddressRequest.cs
+++ b/src/ZigBeeNet/ZDO/Command/NetworkAddressRequest.cs
@@ -45,7 +45,7 @@ namespace ZigBeeNet.ZDO.Command
             ClusterId = 0x0000;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             base.Serialize(serializer);
 
@@ -54,7 +54,7 @@ namespace ZigBeeNet.ZDO.Command
             serializer.Serialize(StartIndex, ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             base.Deserialize(deserializer);
 

--- a/src/ZigBeeNet/ZDO/Command/NetworkAddressResponse.cs
+++ b/src/ZigBeeNet/ZDO/Command/NetworkAddressResponse.cs
@@ -36,7 +36,7 @@ namespace ZigBeeNet.ZDO.Command
             ClusterId = 0x8000;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             base.Serialize(serializer);
 
@@ -52,7 +52,7 @@ namespace ZigBeeNet.ZDO.Command
             }
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             base.Deserialize(deserializer);
 

--- a/src/ZigBeeNet/ZDO/Command/NetworkUpdateRequest.cs
+++ b/src/ZigBeeNet/ZDO/Command/NetworkUpdateRequest.cs
@@ -50,7 +50,7 @@ namespace ZigBeeNet.ZDO.Command
             ClusterId = 0x0038;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             base.Serialize(serializer);
 
@@ -61,7 +61,7 @@ namespace ZigBeeNet.ZDO.Command
             serializer.Serialize(NwkManagerAddr, ZclDataType.Get(DataType.NWK_ADDRESS));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             base.Deserialize(deserializer);
 

--- a/src/ZigBeeNet/ZDO/Command/NodeDescriptorRequest.cs
+++ b/src/ZigBeeNet/ZDO/Command/NodeDescriptorRequest.cs
@@ -8,38 +8,47 @@ using ZigBeeNet.ZCL.Protocol;
 namespace ZigBeeNet.ZDO.Command
 {
     /// <summary>
-     /// Node Descriptor Request value object class.
-     /// 
-     /// The Node_Desc_req command is generated from a local device wishing to inquire
-     /// as to the node descriptor of a remote device. This command shall be unicast either
-     /// to the remote device itself or to an alternative device that contains the discovery
-     /// information of the remote device.
-     /// 
-     /// Code is auto-generated. Modifications may be overwritten!
-     /// </summary>
+    /// Node Descriptor Request value object class.
+    /// 
+    /// The Node_Desc_req command is generated from a local device wishing to inquire
+    /// as to the node descriptor of a remote device. This command shall be unicast either
+    /// to the remote device itself or to an alternative device that contains the discovery
+    /// information of the remote device.
+    /// 
+    /// Code is auto-generated. Modifications may be overwritten!
+    /// </summary>
     public class NodeDescriptorRequest : ZdoRequest, IZigBeeTransactionMatcher
     {
         /// <summary>
-         /// NWKAddrOfInterest command message field.
-         /// </summary>
+        /// DestinationAddress command message field.
+        /// </summary>
+        public IZigBeeAddress Destination
+        {
+            get => base.DestinationAddress;
+            set => base.DestinationAddress = value;
+        }
+
+        /// <summary>
+        /// NWKAddrOfInterest command message field.
+        /// </summary>
         public ushort NwkAddrOfInterest { get; set; }
 
         /// <summary>
-         /// Default constructor.
-         /// </summary>
+        /// Default constructor.
+        /// </summary>
         public NodeDescriptorRequest()
         {
             ClusterId = 0x0002;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             base.Serialize(serializer);
 
             serializer.Serialize(NwkAddrOfInterest, ZclDataType.Get(DataType.NWK_ADDRESS));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             base.Deserialize(deserializer);
 

--- a/src/ZigBeeNet/ZDO/Command/NodeDescriptorResponse.cs
+++ b/src/ZigBeeNet/ZDO/Command/NodeDescriptorResponse.cs
@@ -57,7 +57,7 @@ namespace ZigBeeNet.ZDO.Command
             ClusterId = 0x8002;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             base.Serialize(serializer);
 
@@ -66,7 +66,7 @@ namespace ZigBeeNet.ZDO.Command
             serializer.Serialize(NodeDescriptor, ZclDataType.Get(DataType.NODE_DESCRIPTOR));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             base.Deserialize(deserializer);
 

--- a/src/ZigBeeNet/ZDO/Command/PowerDescriptorRequest.cs
+++ b/src/ZigBeeNet/ZDO/Command/PowerDescriptorRequest.cs
@@ -31,14 +31,14 @@ namespace ZigBeeNet.ZDO.Command
             ClusterId = 0x0003;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             base.Serialize(serializer);
 
             serializer.Serialize(NwkAddrOfInterest, ZclDataType.Get(DataType.NWK_ADDRESS));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             base.Deserialize(deserializer);
 

--- a/src/ZigBeeNet/ZDO/Command/PowerDescriptorResponse.cs
+++ b/src/ZigBeeNet/ZDO/Command/PowerDescriptorResponse.cs
@@ -36,7 +36,7 @@ namespace ZigBeeNet.ZDO.Command
             ClusterId = 0x8003;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             base.Serialize(serializer);
 
@@ -45,7 +45,7 @@ namespace ZigBeeNet.ZDO.Command
             serializer.Serialize(PowerDescriptor, ZclDataType.Get(DataType.POWER_DESCRIPTOR));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             base.Deserialize(deserializer);
 

--- a/src/ZigBeeNet/ZDO/Command/RecoverSourceBindRequest.cs
+++ b/src/ZigBeeNet/ZDO/Command/RecoverSourceBindRequest.cs
@@ -30,14 +30,14 @@ namespace ZigBeeNet.ZDO.Command
             ClusterId = 0x002A;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             base.Serialize(serializer);
 
             serializer.Serialize(StartIndex, ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             base.Deserialize(deserializer);
 

--- a/src/ZigBeeNet/ZDO/Command/RemoveBackupBindEntryResponse.cs
+++ b/src/ZigBeeNet/ZDO/Command/RemoveBackupBindEntryResponse.cs
@@ -35,7 +35,7 @@ namespace ZigBeeNet.ZDO.Command
             ClusterId = 0x8026;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             base.Serialize(serializer);
 
@@ -43,7 +43,7 @@ namespace ZigBeeNet.ZDO.Command
             serializer.Serialize(EntryCount, ZclDataType.Get(DataType.UNSIGNED_16_BIT_INTEGER));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             base.Deserialize(deserializer);
 

--- a/src/ZigBeeNet/ZDO/Command/ReplaceDeviceResponse.cs
+++ b/src/ZigBeeNet/ZDO/Command/ReplaceDeviceResponse.cs
@@ -31,14 +31,14 @@ namespace ZigBeeNet.ZDO.Command
             ClusterId = 0x8024;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             base.Serialize(serializer);
 
             serializer.Serialize(Status, ZclDataType.Get(DataType.ZDO_STATUS));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             base.Deserialize(deserializer);
 

--- a/src/ZigBeeNet/ZDO/Command/SimpleDescriptorRequest.cs
+++ b/src/ZigBeeNet/ZDO/Command/SimpleDescriptorRequest.cs
@@ -36,7 +36,7 @@ namespace ZigBeeNet.ZDO.Command
         }
 
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             base.Serialize(serializer);
 

--- a/src/ZigBeeNet/ZDO/Command/SimpleDescriptorResponse.cs
+++ b/src/ZigBeeNet/ZDO/Command/SimpleDescriptorResponse.cs
@@ -39,7 +39,7 @@ namespace ZigBeeNet.ZDO.Command
             ClusterId = 0x8004;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             base.Serialize(serializer);
 
@@ -49,7 +49,7 @@ namespace ZigBeeNet.ZDO.Command
             serializer.Serialize(SimpleDescriptor, ZclDataType.Get(DataType.SIMPLE_DESCRIPTOR));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             base.Deserialize(deserializer);
 

--- a/src/ZigBeeNet/ZDO/Command/StoreBackupBindEntryResponse.cs
+++ b/src/ZigBeeNet/ZDO/Command/StoreBackupBindEntryResponse.cs
@@ -31,14 +31,14 @@ namespace ZigBeeNet.ZDO.Command
             ClusterId = 0x8025;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             base.Serialize(serializer);
 
             serializer.Serialize(Status, ZclDataType.Get(DataType.ZDO_STATUS));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             base.Deserialize(deserializer);
 

--- a/src/ZigBeeNet/ZDO/Command/UnbindRequest.cs
+++ b/src/ZigBeeNet/ZDO/Command/UnbindRequest.cs
@@ -75,7 +75,7 @@ namespace ZigBeeNet.ZDO.Command
             ClusterId = 0x0022;
         }
         
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             base.Serialize(serializer);
 
@@ -87,7 +87,7 @@ namespace ZigBeeNet.ZDO.Command
             serializer.Serialize(DstEndpoint, ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             base.Deserialize(deserializer);
 

--- a/src/ZigBeeNet/ZDO/Command/UnbindResponse.cs
+++ b/src/ZigBeeNet/ZDO/Command/UnbindResponse.cs
@@ -31,14 +31,14 @@ namespace ZigBeeNet.ZDO.Command
             ClusterId = 0x8022;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             base.Serialize(serializer);
 
             serializer.Serialize(Status, ZclDataType.Get(DataType.ZDO_STATUS));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             base.Deserialize(deserializer);
 

--- a/src/ZigBeeNet/ZDO/Command/UserDescriptorRequest.cs
+++ b/src/ZigBeeNet/ZDO/Command/UserDescriptorRequest.cs
@@ -30,14 +30,14 @@ namespace ZigBeeNet.ZDO.Command
             ClusterId = 0x0011;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             base.Serialize(serializer);
 
             serializer.Serialize(NwkAddrOfInterest, ZclDataType.Get(DataType.NWK_ADDRESS));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             base.Deserialize(deserializer);
 

--- a/src/ZigBeeNet/ZDO/Command/UserDescriptorResponse.cs
+++ b/src/ZigBeeNet/ZDO/Command/UserDescriptorResponse.cs
@@ -40,7 +40,7 @@ namespace ZigBeeNet.ZDO.Command
             ClusterId = 0x8011;
         }
 
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             base.Serialize(serializer);
 
@@ -50,7 +50,7 @@ namespace ZigBeeNet.ZDO.Command
             serializer.Serialize(UserDescriptor, ZclDataType.Get(DataType.USER_DESCRIPTOR));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             base.Deserialize(deserializer);
 

--- a/src/ZigBeeNet/ZDO/ZdoCommand.cs
+++ b/src/ZigBeeNet/ZDO/ZdoCommand.cs
@@ -8,12 +8,12 @@ namespace ZigBeeNet.ZDO
 {
     public class ZdoCommand : ZigBeeCommand
     {
-        public override void Serialize(ZclFieldSerializer serializer)
+        internal override void Serialize(ZclFieldSerializer serializer)
         {
             serializer.Serialize((byte)0, ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));
         }
 
-        public override void Deserialize(ZclFieldDeserializer deserializer)
+        internal override void Deserialize(ZclFieldDeserializer deserializer)
         {
             deserializer.Deserialize(ZclDataType.Get(DataType.UNSIGNED_8_BIT_INTEGER));
         }

--- a/src/ZigBeeNet/ZigBeeCommand.cs
+++ b/src/ZigBeeNet/ZigBeeCommand.cs
@@ -1,28 +1,32 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using System.Text;
 using ZigBeeNet.ZCL;
 
+[assembly: InternalsVisibleTo("ZigBeeNet.Test"),
+    InternalsVisibleTo("ZigBeeNet.Hardware.TI.CC2531.Test"),
+    InternalsVisibleTo("ZigBeeNet.Hardware.Digi.XBee.Test")]
 namespace ZigBeeNet
 {
     public class ZigBeeCommand
     {
-        public IZigBeeAddress SourceAddress { get; set; }
+        internal IZigBeeAddress SourceAddress { get; set; }
 
-        public IZigBeeAddress DestinationAddress { get; set; }
+        internal IZigBeeAddress DestinationAddress { get; set; }
 
-        public ushort ClusterId { get; set; }
+        internal ushort ClusterId { get; set; }
 
-        public byte? TransactionId { get; set; }
+        internal byte? TransactionId { get; set; }
 
-        public bool ApsSecurity { get; set; }
+        internal bool ApsSecurity { get; set; }
 
-        public virtual void Serialize(ZclFieldSerializer serializer)
+        internal virtual void Serialize(ZclFieldSerializer serializer)
         {
             // Default implementation does nothing - overridden by each class
         }
 
-        public virtual void Deserialize(ZclFieldDeserializer deserializer)
+        internal virtual void Deserialize(ZclFieldDeserializer deserializer)
         {
             // Default implementation does nothing - overridden by each class
         }


### PR DESCRIPTION
Makes the properties of `ZigBeeCommand` and `ZclCommand` internal so that ZigbeeNet users are not unnecessarily confused as to which properties to set in each command.
So in the `MoveToColorCommand` only `ColorX`, `ColorY` and `TransitionTime` are available instead of `ColorX`, `ColorY`, `TransitionTime`, `GenericCommand`, `CommandId`, `CommandDirection`, `SourceAddress` and so on.
Commands that need internal properties, such as `NodeDescriptorRequest`, must encapsulate these properties with their own property. In the example of `NodeDescriptorRequest` there is now the property `Destination` which refers to `DestinationAddress`.