### PR TITLE
Changes ZigBeeNet.Transport.SerialPort.csproj to netstandard

### DIFF
--- a/src/ZigBeeNet.Transport.SerialPort/ZigBeeNet.Transport.SerialPort.csproj
+++ b/src/ZigBeeNet.Transport.SerialPort/ZigBeeNet.Transport.SerialPort.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
So we can use this library in .Net Framework applications